### PR TITLE
Add ASTTransformer and Extender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Add `toc.Transformer` to generate a table of contents to the front of any
+  document parsed by a Goldmark parser.
+- Add `toc.Extender` to extend a `goldmark.Markdown` object with the
+  transformer.
+
 ## [0.1.0] - 2021-03-23
 - Initial release.
 

--- a/extend.go
+++ b/extend.go
@@ -1,0 +1,41 @@
+package toc
+
+import (
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/util"
+)
+
+// Extender extends a Goldmark Markdown parser and renderer to always include
+// a table of contents in the output.
+//
+// To use this, install it into your Goldmark Markdown object.
+//
+//   md := goldmark.New(
+//     // ...
+//     goldmark.WithParserOptions(parser.WithAutoHeadingID()),
+//     goldmark.WithExtensions(
+//       // ...
+//       &toc.Extender{
+//       },
+//     ),
+//   )
+//
+// This will install the default Transformer. For more control, install the
+// Transformer directly on the Markdown Parser.
+//
+// NOTE: Unless you've supplied your own parser.IDs implementation, you'll
+// need to enable the WithAutoHeadingID option on the parser to generate IDs
+// and links for headings.
+type Extender struct {
+}
+
+// Extend adds support for rendering a table of contents to the provided
+// Markdown parser/renderer.
+func (*Extender) Extend(md goldmark.Markdown) {
+	md.Parser().AddOptions(
+		parser.WithASTTransformers(
+			util.Prioritized(&Transformer{}, 100),
+		),
+	)
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,21 @@
+package toc_test
+
+import (
+	"testing"
+
+	toc "github.com/abhinav/goldmark-toc"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	goldtestutil "github.com/yuin/goldmark/testutil"
+)
+
+func TestIntegration(t *testing.T) {
+	t.Parallel()
+
+	md := goldmark.New(
+		goldmark.WithExtensions(&toc.Extender{}),
+		goldmark.WithParserOptions(parser.WithAutoHeadingID()),
+	)
+
+	goldtestutil.DoTestCaseFile(md, "testdata/tests.txt", t)
+}

--- a/testdata/tests.txt
+++ b/testdata/tests.txt
@@ -1,0 +1,54 @@
+1
+//- - - - - - - - -//
+No headers.
+//- - - - - - - - -//
+<p>No headers.</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+2
+//- - - - - - - - -//
+# Hello
+
+World
+//- - - - - - - - -//
+<h1>Table of Contents</h1>
+<ul>
+<li>
+<a href="#hello">Hello</a></li>
+</ul>
+<h1 id="hello">Hello</h1>
+<p>World</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+3
+//- - - - - - - - -//
+# Foo
+
+## Bar
+
+# Baz
+
+### Qux
+//- - - - - - - - -//
+<h1>Table of Contents</h1>
+<ul>
+<li>
+<a href="#foo">Foo</a><ul>
+<li>
+<a href="#bar">Bar</a></li>
+</ul>
+</li>
+<li>
+<a href="#baz">Baz</a><ul>
+<li>
+<ul>
+<li>
+<a href="#qux">Qux</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<h1 id="foo">Foo</h1>
+<h2 id="bar">Bar</h2>
+<h1 id="baz">Baz</h1>
+<h3 id="qux">Qux</h3>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/transform.go
+++ b/transform.go
@@ -1,0 +1,64 @@
+package toc
+
+import (
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+const _defaultTitle = "Table of Contents"
+
+// Transformer is a Goldmark AST transformer adds a TOC to the top of a
+// Markdown document.
+//
+// To use this, either install the Extender on the goldmark.Markdown object,
+// or install the AST transformer on the Markdown parser like so.
+//
+//   markdown := goldmark.New(...)
+//   markdown.Parser().AddOptions(
+//     parser.WithAutoHeadingID(),
+//     parser.WithASTTransformers(
+//       util.Prioritized(&toc.Transformer{}, 100),
+//     ),
+//   )
+//
+// NOTE: Unless you've supplied your own parser.IDs implementation, you'll
+// need to enable the WithAutoHeadingID option on the parser to generate IDs
+// and links for headings.
+type Transformer struct {
+	// Title is the title of the table of contents section.
+	// Defaults to "Table of Contents" if unspecified.
+	Title string
+}
+
+var _ parser.ASTTransformer = (*Transformer)(nil) // interface compliance
+
+// Transform adds a table of contents to the provided Markdown document.
+//
+// Errors encountered while transforming are ignored. For more fine-grained
+// control, use Inspect and transform the document manually.
+func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, pctx parser.Context) {
+	toc, err := Inspect(doc, reader.Source())
+	if err != nil {
+		// There are currently no scenarios under which Inspect
+		// returns an error but we have to account for it anyway.
+		return
+	}
+
+	// Don't add anything for documents with no headings.
+	if len(toc.Items) == 0 {
+		return
+	}
+
+	doc.InsertBefore(doc, doc.FirstChild(), RenderList(toc))
+
+	title := t.Title
+	if len(title) == 0 {
+		title = _defaultTitle
+	}
+
+	heading := ast.NewHeading(1)
+	heading.AppendChild(heading, ast.NewString([]byte(title)))
+
+	doc.InsertBefore(doc, doc.FirstChild(), heading)
+}

--- a/transform_test.go
+++ b/transform_test.go
@@ -1,0 +1,61 @@
+package toc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+func TestTransformer(t *testing.T) {
+	src := []byte(strings.Join([]string{
+		"# Foo",
+		"## Bar",
+		"# Baz",
+		"### Qux",
+		"## Quux",
+	}, "\n") + "\n")
+
+	tests := []struct {
+		desc      string
+		giveTitle string
+		wantTitle string
+	}{
+		{
+			desc:      "default title",
+			wantTitle: _defaultTitle,
+		},
+		{
+			desc:      "custom title",
+			giveTitle: "Contents",
+			wantTitle: "Contents",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // for t.Parallel
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			doc := parser.NewParser(
+				parser.WithInlineParsers(parser.DefaultInlineParsers()...),
+				parser.WithBlockParsers(parser.DefaultBlockParsers()...),
+				parser.WithAutoHeadingID(),
+				parser.WithASTTransformers(
+					util.Prioritized(&Transformer{
+						Title: tt.giveTitle,
+					}, 100),
+				),
+			).Parse(text.NewReader(src))
+
+			heading, ok := doc.FirstChild().(*ast.Heading)
+			require.True(t, ok, "first child must be a heading, got %T", doc.FirstChild())
+			assert.Equal(t, tt.wantTitle, string(heading.Text(src)), "title mismatch")
+		})
+	}
+}


### PR DESCRIPTION
This adds a goldmkar.ASTTransformer that prepends the table of contents
to a document, and a goldmark.Extender that installs this transformer
into the parser.

This allows inclusion of a table of contents to documents more easily
for common cases.
