### PR TITLE
v0.2: Turn into shim around 0.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ '*' ]
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 - 2023-02-11
+### Changed
+- Turn module into a shim around go.abhg.dev/goldmark/toc.
+
 ## [0.2.1] - 2021-12-15
 ### Fixed
 - inspect: Correctly handle escaped punctuation in titles.

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,12 @@ golint: $(GOLINT)
 
 .PHONY: staticcheck
 staticcheck: $(STATICCHECK)
-	$(STATICCHECK) ./...
+	$(eval STATICCHECK_LOG := $(shell mktemp -t staticcheck.XXXXX))
+	$(STATICCHECK) ./... | grep -v SA1019 > $(STATICCHECK_LOG) || true
+	@[ ! -s "$(STATICCHECK_LOG)" ] || \
+		(echo "static failed:" | \
+		cat - $(STATICCHECK_LOG) && false)
+
 
 tools: $(GOLINT) $(STATICCHECK)
 

--- a/doc.go
+++ b/doc.go
@@ -5,61 +5,63 @@
 // inspection, the package analyzes an existing Markdown document, and builds
 // a Table of Contents from it.
 //
-//  markdown := goldmark.New(...)
+//	markdown := goldmark.New(...)
 //
-//  parser := markdown.Parser()
-//  doc := parser.Parse(text.NewReader(src))
-//  tocTree, err := toc.Inspect(doc, src)
+//	parser := markdown.Parser()
+//	doc := parser.Parse(text.NewReader(src))
+//	tocTree, err := toc.Inspect(doc, src)
 //
 // During rendering, it converts the Table of Contents into a list of headings
 // with nested items under each as a goldmark Markdown document. You may
 // manipulate the TOC, removing items from it or simplifying it, before
 // rendering.
 //
-//  tocList := toc.RenderList(tocTree)
+//	tocList := toc.RenderList(tocTree)
 //
 // You can render that Markdown document using goldmark into whatever form you
 // prefer.
 //
-//  renderer := markdown.Renderer()
-//  renderer.Render(out, src, tocList)
+//	renderer := markdown.Renderer()
+//	renderer.Render(out, src, tocList)
 //
 // The following diagram summarizes the flow of information with goldmark-toc.
 //
-//      src
-//   +--------+                           +-------------------+
-//   |        |   goldmark/Parser.Parse   |                   |
-//   | []byte :---------------------------> goldmark/ast.Node |
-//   |        |                           |                   |
-//   +---.----+                           +-------.-----.-----+
-//       |                                        |     |
-//       '----------------.     .-----------------'     |
-//                         \   /                        |
-//                          \ /                         |
-//                           |                          |
-//                           | toc.Inspect              |
-//                           |                          |
-//                      +----v----+                     |
-//                      |         |                     |
-//                      | toc.TOC |                     |
-//                      |         |                     |
-//                      +----.----+                     |
-//                           |                          |
-//                           | toc/Renderer.Render      |
-//                           |                          |
-//                 +---------v---------+                |
-//                 |                   |                |
-//                 | goldmark/ast.Node |                |
-//                 |                   |                |
-//                 +---------.---------+                |
-//                           |                          |
-//                           '-------.   .--------------'
-//                                    \ /
-//                                     |
-//            goldmark/Renderer.Render |
-//                                     |
-//                                     v
-//                                 +------+
-//                                 | HTML |
-//                                 +------+
+//	   src
+//	+--------+                           +-------------------+
+//	|        |   goldmark/Parser.Parse   |                   |
+//	| []byte :---------------------------> goldmark/ast.Node |
+//	|        |                           |                   |
+//	+---.----+                           +-------.-----.-----+
+//	    |                                        |     |
+//	    '----------------.     .-----------------'     |
+//	                      \   /                        |
+//	                       \ /                         |
+//	                        |                          |
+//	                        | toc.Inspect              |
+//	                        |                          |
+//	                   +----v----+                     |
+//	                   |         |                     |
+//	                   | toc.TOC |                     |
+//	                   |         |                     |
+//	                   +----.----+                     |
+//	                        |                          |
+//	                        | toc/Renderer.Render      |
+//	                        |                          |
+//	              +---------v---------+                |
+//	              |                   |                |
+//	              | goldmark/ast.Node |                |
+//	              |                   |                |
+//	              +---------.---------+                |
+//	                        |                          |
+//	                        '-------.   .--------------'
+//	                                 \ /
+//	                                  |
+//	         goldmark/Renderer.Render |
+//	                                  |
+//	                                  v
+//	                              +------+
+//	                              | HTML |
+//	                              +------+
+//
+// Deprecated: Use "go.abhg.dev/goldmark/toc" instead.
 package toc

--- a/extend.go
+++ b/extend.go
@@ -1,25 +1,21 @@
 package toc
 
-import (
-	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/util"
-)
+import "go.abhg.dev/goldmark/toc"
 
 // Extender extends a Goldmark Markdown parser and renderer to always include
 // a table of contents in the output.
 //
 // To use this, install it into your Goldmark Markdown object.
 //
-//   md := goldmark.New(
-//     // ...
-//     goldmark.WithParserOptions(parser.WithAutoHeadingID()),
-//     goldmark.WithExtensions(
-//       // ...
-//       &toc.Extender{
-//       },
-//     ),
-//   )
+//	md := goldmark.New(
+//	  // ...
+//	  goldmark.WithParserOptions(parser.WithAutoHeadingID()),
+//	  goldmark.WithExtensions(
+//	    // ...
+//	    &toc.Extender{
+//	    },
+//	  ),
+//	)
 //
 // This will install the default Transformer. For more control, install the
 // Transformer directly on the Markdown Parser.
@@ -27,15 +23,4 @@ import (
 // NOTE: Unless you've supplied your own parser.IDs implementation, you'll
 // need to enable the WithAutoHeadingID option on the parser to generate IDs
 // and links for headings.
-type Extender struct {
-}
-
-// Extend adds support for rendering a table of contents to the provided
-// Markdown parser/renderer.
-func (*Extender) Extend(md goldmark.Markdown) {
-	md.Parser().AddOptions(
-		parser.WithASTTransformers(
-			util.Prioritized(&Transformer{}, 100),
-		),
-	)
-}
+type Extender = toc.Extender

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use "go.abhg.dev/goldmark/toc" instead.
 module github.com/abhinav/goldmark-toc
 
 go 1.16
@@ -5,4 +6,5 @@ go 1.16
 require (
 	github.com/stretchr/testify v1.7.0
 	github.com/yuin/goldmark v1.3.3
+	go.abhg.dev/goldmark/toc v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,10 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.3.3 h1:37BdQwPx8VOSic8eDSWee6QL9mRpZRm9VJp/QugNrW0=
 github.com/yuin/goldmark v1.3.3/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+go.abhg.dev/goldmark/toc v0.3.0 h1:jtRGFHfx9XxvZpLLaiqIN+sHZyQ44AH7RYnnXGYBnU4=
+go.abhg.dev/goldmark/toc v0.3.0/go.mod h1:F2YzBaOr2D1cH5DBrORx3Oj+UMsYF6JbFeBO6Xg5jRs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/render.go
+++ b/render.go
@@ -1,78 +1,29 @@
 package toc
 
-import "github.com/yuin/goldmark/ast"
-
-const _defaultMarker = '*'
+import (
+	"github.com/yuin/goldmark/ast"
+	"go.abhg.dev/goldmark/toc"
+)
 
 // RenderList renders a table of contents as a nested list with a sane,
 // default configuration for the ListRenderer.
-func RenderList(toc *TOC) ast.Node {
-	return new(ListRenderer).Render(toc)
+func RenderList(t *TOC) ast.Node {
+	return toc.RenderList(t)
 }
 
 // ListRenderer builds a nested list from a table of contents.
 //
 // For example,
 //
-//  # Foo
-//  ## Bar
-//  ## Baz
-//  # Qux
+//	# Foo
+//	## Bar
+//	## Baz
+//	# Qux
 //
 // Becomes,
 //
-//  - Foo
-//    - Bar
-//    - Baz
-//  - Qux
-type ListRenderer struct {
-	// Marker for elements of the list, e.g. '-', '*', etc.
-	//
-	// Defaults to '*'.
-	Marker byte
-}
-
-// Render renders the table of contents into Markdown.
-func (r *ListRenderer) Render(toc *TOC) ast.Node {
-	return r.renderItems(toc.Items)
-}
-
-func (r *ListRenderer) renderItems(items Items) ast.Node {
-	if len(items) == 0 {
-		return nil
-	}
-
-	mkr := r.Marker
-	if mkr == 0 {
-		mkr = _defaultMarker
-	}
-
-	list := ast.NewList(mkr)
-	for _, item := range items {
-		list.AppendChild(list, r.renderItem(item))
-	}
-	return list
-}
-
-func (r *ListRenderer) renderItem(n *Item) ast.Node {
-	item := ast.NewListItem(0)
-
-	if t := n.Title; len(t) > 0 {
-		title := ast.NewString(t)
-		title.SetRaw(true)
-		if len(n.ID) > 0 {
-			link := ast.NewLink()
-			link.Destination = append([]byte("#"), n.ID...)
-			link.AppendChild(link, title)
-			item.AppendChild(item, link)
-		} else {
-			item.AppendChild(item, title)
-		}
-	}
-
-	if items := r.renderItems(n.Items); items != nil {
-		item.AppendChild(item, items)
-	}
-
-	return item
-}
+//   - Foo
+//   - Bar
+//   - Baz
+//   - Qux
+type ListRenderer = toc.ListRenderer

--- a/toc.go
+++ b/toc.go
@@ -1,36 +1,13 @@
 package toc
 
+import "go.abhg.dev/goldmark/toc"
+
 // TOC is the table of contents. It's the top-level object under which the
 // rest of the table of contents resides.
-type TOC struct {
-	// Items holds the top-level headings under the table of contents.
-	Items Items
-}
+type TOC = toc.TOC
 
 // Item is a single item in the table of contents.
-type Item struct {
-	// Title of this item in the table of contents.
-	//
-	// This may be blank for items that don't refer to a heading, and only
-	// have sub-items.
-	Title []byte
-
-	// ID is the identifier for the heading that this item refers to. This
-	// is the fragment portion of the link without the "#".
-	//
-	// This may be blank if the item doesn't have an id assigned to it, or
-	// if it doesn't have a title.
-	//
-	// Enable AutoHeadingID in your parser if you expected these to be set
-	// but they weren't.
-	ID []byte
-
-	// Items references children of this item.
-	//
-	// For a heading at level 3, Items, contains the headings at level 4
-	// under that section.
-	Items Items
-}
+type Item = toc.Item
 
 // Items is a list of items in a table of contents.
-type Items []*Item
+type Items = toc.Items

--- a/transform.go
+++ b/transform.go
@@ -1,12 +1,6 @@
 package toc
 
-import (
-	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/text"
-)
-
-const _defaultTitle = "Table of Contents"
+import "go.abhg.dev/goldmark/toc"
 
 // Transformer is a Goldmark AST transformer adds a TOC to the top of a
 // Markdown document.
@@ -14,51 +8,15 @@ const _defaultTitle = "Table of Contents"
 // To use this, either install the Extender on the goldmark.Markdown object,
 // or install the AST transformer on the Markdown parser like so.
 //
-//   markdown := goldmark.New(...)
-//   markdown.Parser().AddOptions(
-//     parser.WithAutoHeadingID(),
-//     parser.WithASTTransformers(
-//       util.Prioritized(&toc.Transformer{}, 100),
-//     ),
-//   )
+//	markdown := goldmark.New(...)
+//	markdown.Parser().AddOptions(
+//	  parser.WithAutoHeadingID(),
+//	  parser.WithASTTransformers(
+//	    util.Prioritized(&toc.Transformer{}, 100),
+//	  ),
+//	)
 //
 // NOTE: Unless you've supplied your own parser.IDs implementation, you'll
 // need to enable the WithAutoHeadingID option on the parser to generate IDs
 // and links for headings.
-type Transformer struct {
-	// Title is the title of the table of contents section.
-	// Defaults to "Table of Contents" if unspecified.
-	Title string
-}
-
-var _ parser.ASTTransformer = (*Transformer)(nil) // interface compliance
-
-// Transform adds a table of contents to the provided Markdown document.
-//
-// Errors encountered while transforming are ignored. For more fine-grained
-// control, use Inspect and transform the document manually.
-func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, pctx parser.Context) {
-	toc, err := Inspect(doc, reader.Source())
-	if err != nil {
-		// There are currently no scenarios under which Inspect
-		// returns an error but we have to account for it anyway.
-		return
-	}
-
-	// Don't add anything for documents with no headings.
-	if len(toc.Items) == 0 {
-		return
-	}
-
-	doc.InsertBefore(doc, doc.FirstChild(), RenderList(toc))
-
-	title := t.Title
-	if len(title) == 0 {
-		title = _defaultTitle
-	}
-
-	heading := ast.NewHeading(1)
-	heading.AppendChild(heading, ast.NewString([]byte(title)))
-
-	doc.InsertBefore(doc, doc.FirstChild(), heading)
-}
+type Transformer = toc.Transformer

--- a/transform_test.go
+++ b/transform_test.go
@@ -28,7 +28,7 @@ func TestTransformer(t *testing.T) {
 	}{
 		{
 			desc:      "default title",
-			wantTitle: _defaultTitle,
+			wantTitle: "Table of Contents",
 		},
 		{
 			desc:      "custom title",


### PR DESCRIPTION
Turns v0.2 into a shim around the v0.3 with a different import path.
