### PR TITLE
Extender: Add Title field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Extender: Add Title field to change the Table of Contents title.
+
 ## [0.3.0] - 2022-12-19
 ### Changed
 - Change the module path to `go.abhg.dev/goldmark/toc`.

--- a/README.md
+++ b/README.md
@@ -63,11 +63,22 @@ document parsed by this Markdown object.
 > a custom implementation of `parser.IDs`, none of the headings in the
 > document will have links generated for them.
 
+#### Changing the title
+
+If you want to use a title other than "Table of Contents",
+set the `Title` field of `Extender`.
+
+```go
+&toc.Extender{
+  Title: "Contents",
+}
+```
+
 ### Transformer
 
 Installing this package as an AST Transformer provides slightly more control
-over the output. To use it, install the AST transformer on the Goldmark
-Markdown parser.
+over the output.
+To use it, install the AST transformer on the Goldmark Markdown parser.
 
 ```go
 markdown := goldmark.New(...)

--- a/extend.go
+++ b/extend.go
@@ -28,14 +28,19 @@ import (
 // need to enable the WithAutoHeadingID option on the parser to generate IDs
 // and links for headings.
 type Extender struct {
+	// Title is the title of the table of contents section.
+	// Defaults to "Table of Contents" if unspecified.
+	Title string
 }
 
 // Extend adds support for rendering a table of contents to the provided
 // Markdown parser/renderer.
-func (*Extender) Extend(md goldmark.Markdown) {
+func (e *Extender) Extend(md goldmark.Markdown) {
 	md.Parser().AddOptions(
 		parser.WithASTTransformers(
-			util.Prioritized(&Transformer{}, 100),
+			util.Prioritized(&Transformer{
+				Title: e.Title,
+			}, 100),
 		),
 	)
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -19,21 +19,24 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	var tests []struct {
-		Desc string `yaml:"desc"`
-		Give string `yaml:"give"`
-		Want string `yaml:"want"`
+		Desc  string `yaml:"desc"`
+		Give  string `yaml:"give"`
+		Want  string `yaml:"want"`
+		Title string `yaml:"title"`
 	}
 	require.NoError(t, yaml.Unmarshal(testsdata, &tests))
-
-	md := goldmark.New(
-		goldmark.WithExtensions(&toc.Extender{}),
-		goldmark.WithParserOptions(parser.WithAutoHeadingID()),
-	)
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.Desc, func(t *testing.T) {
 			t.Parallel()
+
+			md := goldmark.New(
+				goldmark.WithExtensions(&toc.Extender{
+					Title: tt.Title,
+				}),
+				goldmark.WithParserOptions(parser.WithAutoHeadingID()),
+			)
 
 			var buf bytes.Buffer
 			require.NoError(t, md.Convert([]byte(tt.Give), &buf))

--- a/testdata/tests.yaml
+++ b/testdata/tests.yaml
@@ -91,3 +91,18 @@
     <a href="#formatted-header">Formatted header</a></li>
     </ul>
     <h1 id="formatted-header"><strong>Formatted</strong> <code>header</code></h1>
+
+- desc: title change
+  title: Contents
+  give: |
+    # Hello
+
+    World
+  want: |
+    <h1>Contents</h1>
+    <ul>
+    <li>
+    <a href="#hello">Hello</a></li>
+    </ul>
+    <h1 id="hello">Hello</h1>
+    <p>World</p>


### PR DESCRIPTION
Adds a Title field to Extender
to change the title of the Table of Contents section
without adding the Transformer.