### PR TITLE
Add MaxDepth option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Extender: Add Title field to change the Table of Contents title.
+- Inspect: Add MaxDepth option to limit the depth of the Table of Contents.
 
 ## [0.3.0] - 2022-12-19
 ### Changed

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ set the `Title` field of `Extender`.
 }
 ```
 
+#### Limiting the Table of Contents
+
+By default, goldmark-toc will include all headers in the table of contents.
+If you want to limit the depth of the table of contents,
+use the `MaxDepth` field.
+
+```go
+&toc.Extender{
+  MaxDepth: 3,
+}
+```
+
+Headers with a level higher than the specified value
+will not be included in the table of contents.
+
 ### Transformer
 
 Installing this package as an AST Transformer provides slightly more control
@@ -136,6 +151,13 @@ tree, err := toc.Inspect(doc, src)
 if err != nil {
   // handle the error
 }
+```
+
+If you need to limit the depth of the table of contents,
+use the `MaxDepth` option.
+
+```go
+tree, err := toc.Inspect(doc, src, toc.MaxDepth(3))
 ```
 
 #### Generate a Markdown list

--- a/extend.go
+++ b/extend.go
@@ -31,6 +31,13 @@ type Extender struct {
 	// Title is the title of the table of contents section.
 	// Defaults to "Table of Contents" if unspecified.
 	Title string
+
+	// MaxDepth is the maximum depth of the table of contents.
+	// Headings with a level greater than the specified depth will be ignored.
+	// See the documentation for MaxDepth for more information.
+	//
+	// Defaults to 0 (no limit) if unspecified.
+	MaxDepth int
 }
 
 // Extend adds support for rendering a table of contents to the provided
@@ -39,7 +46,8 @@ func (e *Extender) Extend(md goldmark.Markdown) {
 	md.Parser().AddOptions(
 		parser.WithASTTransformers(
 			util.Prioritized(&Transformer{
-				Title: e.Title,
+				Title:    e.Title,
+				MaxDepth: e.MaxDepth,
 			}, 100),
 		),
 	)

--- a/integration_test.go
+++ b/integration_test.go
@@ -23,6 +23,8 @@ func TestIntegration(t *testing.T) {
 		Give  string `yaml:"give"`
 		Want  string `yaml:"want"`
 		Title string `yaml:"title"`
+
+		MaxDepth int `yaml:"maxDepth"`
 	}
 	require.NoError(t, yaml.Unmarshal(testsdata, &tests))
 
@@ -33,7 +35,8 @@ func TestIntegration(t *testing.T) {
 
 			md := goldmark.New(
 				goldmark.WithExtensions(&toc.Extender{
-					Title: tt.Title,
+					Title:    tt.Title,
+					MaxDepth: tt.MaxDepth,
 				}),
 				goldmark.WithParserOptions(parser.WithAutoHeadingID()),
 			)

--- a/render.go
+++ b/render.go
@@ -19,12 +19,12 @@ func RenderList(toc *TOC) ast.Node {
 //	## Baz
 //	# Qux
 //
-// Becomes,
+//	// becomes
 //
-//   - Foo
-//   - Bar
-//   - Baz
-//   - Qux
+//	- Foo
+//	  - Bar
+//	  - Baz
+//	- Qux
 type ListRenderer struct {
 	// Marker for elements of the list, e.g. '-', '*', etc.
 	//

--- a/testdata/tests.yaml
+++ b/testdata/tests.yaml
@@ -106,3 +106,26 @@
     </ul>
     <h1 id="hello">Hello</h1>
     <p>World</p>
+
+- desc: maxDepth
+  maxDepth: 1
+  give: |
+    # Foo
+
+    ## Bar
+
+    # Baz
+
+    ### Qux
+  want: |
+    <h1>Table of Contents</h1>
+    <ul>
+    <li>
+    <a href="#foo">Foo</a></li>
+    <li>
+    <a href="#baz">Baz</a></li>
+    </ul>
+    <h1 id="foo">Foo</h1>
+    <h2 id="bar">Bar</h2>
+    <h1 id="baz">Baz</h1>
+    <h3 id="qux">Qux</h3>

--- a/transform.go
+++ b/transform.go
@@ -29,6 +29,10 @@ type Transformer struct {
 	// Title is the title of the table of contents section.
 	// Defaults to "Table of Contents" if unspecified.
 	Title string
+
+	// MaxDepth is the maximum depth of the table of contents.
+	// See the documentation for MaxDepth for more information.
+	MaxDepth int
 }
 
 var _ parser.ASTTransformer = (*Transformer)(nil) // interface compliance
@@ -38,7 +42,7 @@ var _ parser.ASTTransformer = (*Transformer)(nil) // interface compliance
 // Errors encountered while transforming are ignored. For more fine-grained
 // control, use Inspect and transform the document manually.
 func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, pctx parser.Context) {
-	toc, err := Inspect(doc, reader.Source())
+	toc, err := Inspect(doc, reader.Source(), MaxDepth(t.MaxDepth))
 	if err != nil {
 		// There are currently no scenarios under which Inspect
 		// returns an error but we have to account for it anyway.


### PR DESCRIPTION
Adds a MaxDepth option that limits the depth of the table of contents.
Headers higher than the given number will be ignored.

