### PR TITLE
doc: Clarify handling of documents without headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,15 @@ You may manipulate the `tree` before rendering the list.
 Finally, render this table of contents along with your Markdown document:
 
 ```go
-markdown.Renderer().Render(output, src, list) // table of contents
-markdown.Renderer().Render(output, src, doc)  // document
+// Render the table of contents.
+if list != nil {
+    // list will be nil if the table of contents is empty
+    // because there were no headings in the document.
+    markdown.Renderer().Render(output, src, list)
+}
+
+// Render the document.
+markdown.Renderer().Render(output, src, doc)
 ```
 
 Alternatively, include the table of contents into your Markdown document in
@@ -188,7 +195,9 @@ your desired position and render it using your Markdown renderer.
 
 ```go
 // Prepend table of contents to the front of the document.
-doc.InsertBefore(doc, doc.FirstChild(), list)
+if list != nil {
+    doc.InsertBefore(doc, doc.FirstChild(), list)
+}
 
 // Render the document.
 markdown.Renderer().Render(output, src, doc)

--- a/doc.go
+++ b/doc.go
@@ -16,6 +16,10 @@
 // manipulate the TOC, removing items from it or simplifying it, before
 // rendering.
 //
+//	if len(tocTree.Items) == 0 {
+//		// No headings in the document.
+//		return
+//	}
 //	tocList := toc.RenderList(tocTree)
 //
 // You can render that Markdown document using goldmark into whatever form you

--- a/example_test.go
+++ b/example_test.go
@@ -43,6 +43,11 @@ Bye
 		panic(err)
 	}
 
+	if len(tree.Items) == 0 {
+		return
+		// No table of contents because there are no headers.
+	}
+
 	// Render the tree as-is into a Markdown list.
 	treeList := toc.RenderList(tree)
 

--- a/inspect.go
+++ b/inspect.go
@@ -68,6 +68,7 @@ func (d maxDepthOption) String() string {
 //
 // The table of contents is represents as a tree where each item represents a
 // heading or a heading level with zero or more children.
+// The returned TOC will be empty if there are no headings in the document.
 //
 // For example,
 //

--- a/render.go
+++ b/render.go
@@ -6,6 +6,9 @@ const _defaultMarker = '*'
 
 // RenderList renders a table of contents as a nested list with a sane,
 // default configuration for the ListRenderer.
+//
+// If the TOC is nil or empty, nil is returned.
+// Do not call Goldmark's renderer if the returned node is nil.
 func RenderList(toc *TOC) ast.Node {
 	return new(ListRenderer).Render(toc)
 }
@@ -33,7 +36,13 @@ type ListRenderer struct {
 }
 
 // Render renders the table of contents into Markdown.
+//
+// If the TOC is nil or empty, nil is returned.
+// Do not call Goldmark's renderer if the returned node is nil.
 func (r *ListRenderer) Render(toc *TOC) ast.Node {
+	if toc == nil {
+		return nil
+	}
 	return r.renderItems(toc.Items)
 }
 

--- a/render_test.go
+++ b/render_test.go
@@ -237,3 +237,9 @@ func TestRenderList(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderList_nil(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, RenderList(nil))
+}

--- a/toc.go
+++ b/toc.go
@@ -4,6 +4,8 @@ package toc
 // rest of the table of contents resides.
 type TOC struct {
 	// Items holds the top-level headings under the table of contents.
+	//
+	// Items is empty if there are no headings in the document.
 	Items Items
 }
 


### PR DESCRIPTION
If a Markdown document has no headings defined in it,
`Inspect` will return a `TOC` without any items in it,
and `RenderList` will return nil.
Attempting to render this will cause a panic.

This is all already handled correctly by the
`Transformer` and the `Extender` (these are plug-and-play).

In manual mode, where users use `Inspect` and `RenderList` directly,
it makes sense to clarify that they need to handle the empty/nil cases.

Clarify this in the documentation where relevant.

Resolves #31
