### PR TITLE
README: Explain how to set <ul> ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,24 @@ if list != nil {
 // Render the document.
 markdown.Renderer().Render(output, src, doc)
 ```
+
+##### Customize TOC attributes
+
+If you want the rendered TOC to have an id or other attributes,
+use [Node.SetAttribute](https://pkg.go.dev/github.com/yuin/goldmark/ast#Node.SetAttribute)
+on the `ast.Node` returned by `toc.RenderList`.
+
+For example, with the following:
+
+```go
+list := toc.RenderList(tree)
+list.SetAttribute([]byte("id"), []byte("toc"))
+```
+
+The output will take the form:
+
+```html
+<ul id="toc">
+  <!-- ... -->
+</ul>
+```

--- a/render_test.go
+++ b/render_test.go
@@ -1,9 +1,12 @@
 package toc
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 )
 
@@ -236,6 +239,26 @@ func TestRenderList(t *testing.T) {
 			tt.want.Match(t, got)
 		})
 	}
+}
+
+func TestRenderList_id(t *testing.T) {
+	t.Parallel()
+
+	node := RenderList(&TOC{
+		Items: Items{
+			item("Foo", "foo",
+				item("Bar", "bar"),
+				item("Baz", "baz"),
+			),
+		},
+	})
+	node.SetAttribute([]byte("id"), []byte("toc"))
+
+	var buf bytes.Buffer
+	err := goldmark.DefaultRenderer().Render(&buf, nil, node)
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), `<ul id="toc">`)
 }
 
 func TestRenderList_nil(t *testing.T) {


### PR DESCRIPTION
Provide instructions on how to set the `id` (or other attributes)
of the `<ul>` generated by `RenderList`.

Refs #35