### PR TITLE
feat(Extender, Transformer): Support ListID

### DIFF
--- a/.changes/unreleased/Added-20230902-144255.yaml
+++ b/.changes/unreleased/Added-20230902-144255.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: |
+  Add a ListID attribute to Extender and Transformer.
+  If set, the rendered `<ul>` will have an `id` attribute with this value.
+time: 2023-09-02T14:42:55.155118683-07:00

--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ set the `Title` field of `Extender`.
 }
 ```
 
+#### Adding an ID
+
+If you want the rendered HTML list to include an id,
+set the `ListID` field of `Extender`.
+
+```go
+&toc.Extender{
+  ListID: "toc",
+}
+```
+
+This will render:
+
+```html
+<ul id="toc">
+  <!-- ... -->
+</ul>
+```
+
 #### Limiting the Table of Contents
 
 By default, goldmark-toc will include all headers in the table of contents.

--- a/extend.go
+++ b/extend.go
@@ -38,6 +38,11 @@ type Extender struct {
 	//
 	// Defaults to 0 (no limit) if unspecified.
 	MaxDepth int
+
+	// ListID is the id for the list of TOC items rendered in the HTML.
+	//
+	// See the documentation for Transformer.ListID for more information.
+	ListID string
 }
 
 // Extend adds support for rendering a table of contents to the provided
@@ -48,6 +53,7 @@ func (e *Extender) Extend(md goldmark.Markdown) {
 			util.Prioritized(&Transformer{
 				Title:    e.Title,
 				MaxDepth: e.MaxDepth,
+				ListID:   e.ListID,
 			}, 100),
 		),
 	)

--- a/integration_test.go
+++ b/integration_test.go
@@ -19,10 +19,11 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	var tests []struct {
-		Desc  string `yaml:"desc"`
-		Give  string `yaml:"give"`
-		Want  string `yaml:"want"`
-		Title string `yaml:"title"`
+		Desc   string `yaml:"desc"`
+		Give   string `yaml:"give"`
+		Want   string `yaml:"want"`
+		Title  string `yaml:"title"`
+		ListID string `yaml:"listID"`
 
 		MaxDepth int `yaml:"maxDepth"`
 	}
@@ -37,6 +38,7 @@ func TestIntegration(t *testing.T) {
 				goldmark.WithExtensions(&toc.Extender{
 					Title:    tt.Title,
 					MaxDepth: tt.MaxDepth,
+					ListID:   tt.ListID,
 				}),
 				goldmark.WithParserOptions(parser.WithAutoHeadingID()),
 			)

--- a/testdata/tests.yaml
+++ b/testdata/tests.yaml
@@ -129,3 +129,20 @@
     <h2 id="bar">Bar</h2>
     <h1 id="baz">Baz</h1>
     <h3 id="qux">Qux</h3>
+
+- desc: list id
+  listID: my-toc
+  give: |
+    # Hello
+
+    # World
+  want: |
+    <h1>Table of Contents</h1>
+    <ul id="my-toc">
+    <li>
+    <a href="#hello">Hello</a></li>
+    <li>
+    <a href="#world">World</a></li>
+    </ul>
+    <h1 id="hello">Hello</h1>
+    <h1 id="world">World</h1>

--- a/transform.go
+++ b/transform.go
@@ -33,6 +33,18 @@ type Transformer struct {
 	// MaxDepth is the maximum depth of the table of contents.
 	// See the documentation for MaxDepth for more information.
 	MaxDepth int
+
+	// ListID is the id for the list of TOC items rendered in the HTML.
+	//
+	// For example, if ListID is "toc", the table of contents will be
+	// rendered as:
+	//
+	//	<ul id="toc">
+	//	  ...
+	//	</ul>
+	//
+	// The HTML element does not have an ID if ListID is empty.
+	ListID string
 }
 
 var _ parser.ASTTransformer = (*Transformer)(nil) // interface compliance
@@ -54,7 +66,12 @@ func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, _ parser.
 		return
 	}
 
-	doc.InsertBefore(doc, doc.FirstChild(), RenderList(toc))
+	listNode := RenderList(toc)
+	if id := t.ListID; len(id) > 0 {
+		listNode.SetAttributeString("id", []byte(id))
+	}
+
+	doc.InsertBefore(doc, doc.FirstChild(), listNode)
 
 	title := t.Title
 	if len(title) == 0 {


### PR DESCRIPTION
Support adding an `id="foo"` attribute on `<ul>`s in automatic mode
by setting a ListID field on Extender or Transformer.

Resolves #35
