### PR TITLE
feat: Add MinDepth option (#40)

### DIFF
--- a/.changes/unreleased/Added-20230911-213518.yaml
+++ b/.changes/unreleased/Added-20230911-213518.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: The new MinDepth option allows ignoring headings below the specified level.
+time: 2023-09-11T21:35:18.694466278-07:00

--- a/README.md
+++ b/README.md
@@ -97,15 +97,16 @@ This will render:
 
 By default, goldmark-toc will include all headers in the table of contents.
 If you want to limit the depth of the table of contents,
-use the `MaxDepth` field.
+use the `MinDepth` and `MaxDepth` field.
 
 ```go
 &toc.Extender{
+  MinDepth: 2,
   MaxDepth: 3,
 }
 ```
 
-Headers with a level higher than the specified value
+Headers with a level lower or higher than the specified values
 will not be included in the table of contents.
 
 #### Compacting the Table of Contents
@@ -210,10 +211,10 @@ if err != nil {
 ```
 
 If you need to limit the depth of the table of contents,
-use the `MaxDepth` option.
+use the `MinDepth` and `MaxDepth` option.
 
 ```go
-tree, err := toc.Inspect(doc, src, toc.MaxDepth(3))
+tree, err := toc.Inspect(doc, src, toc.MinDepth(2), toc.MaxDepth(3))
 ```
 
 #### Generate a Markdown list

--- a/demo/main.go
+++ b/demo/main.go
@@ -23,6 +23,7 @@ func main() {
 type request struct {
 	Markdown string
 	Title    string
+	MinDepth int
 	MaxDepth int
 	Compact  bool
 }
@@ -30,6 +31,7 @@ type request struct {
 func (r *request) Decode(v js.Value) {
 	r.Markdown = v.Get("markdown").String()
 	r.Title = v.Get("title").String()
+	r.MinDepth = v.Get("minDepth").Int()
 	r.MaxDepth = v.Get("maxDepth").Int()
 	r.Compact = v.Get("compact").Bool()
 }
@@ -42,6 +44,7 @@ func formatMarkdown(req request) string {
 		goldmark.WithExtensions(
 			&toc.Extender{
 				Title:    req.Title,
+				MinDepth: req.MinDepth,
 				MaxDepth: req.MaxDepth,
 				Compact:  req.Compact,
 			},

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -58,7 +58,14 @@
         <label for="title">Title</label>
         <input id="title" type="text" value="" />
 
-        <label for="minDepth">Maximum Depth</label>
+        <label for="compact">Compact</label>
+        <input type="checkbox" id="compact" name="compact" checked />
+
+        <br/>
+
+        Depth limit:
+
+        <label for="minDepth">Minimum</label>
         <select id="minDepth" active="after">
           <option value="0" selected>No limit</option>
           <option value="1">1</option>
@@ -69,7 +76,7 @@
           <option value="6">6</option>
         </select>
 
-        <label for="maxDepth">Maximum Depth</label>
+        <label for="maxDepth">Maximum</label>
         <select id="maxDepth" active="after">
           <option value="0" selected>No limit</option>
           <option value="1">1</option>
@@ -80,8 +87,6 @@
           <option value="6">6</option>
         </select>
 
-        <label for="compact">Compact</label>
-        <input type="checkbox" id="compact" name="compact" checked />
       </div>
 
       <div class="output-container">

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -58,6 +58,17 @@
         <label for="title">Title</label>
         <input id="title" type="text" value="" />
 
+        <label for="minDepth">Maximum Depth</label>
+        <select id="minDepth" active="after">
+          <option value="0" selected>No limit</option>
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+        </select>
+
         <label for="maxDepth">Maximum Depth</label>
         <select id="maxDepth" active="after">
           <option value="0" selected>No limit</option>
@@ -82,12 +93,14 @@
 
   <script>
     const input = document.getElementById("input");
+    const minDepth = document.getElementById("minDepth");
     const maxDepth = document.getElementById("maxDepth");
     const compact = document.getElementById("compact");
     const title = document.getElementById("title");
     const output = document.getElementById("output");
 
     input.addEventListener("input", refresh);
+    minDepth.addEventListener("change", refresh);
     maxDepth.addEventListener("change", refresh);
     title.addEventListener("input", refresh);
     compact.addEventListener("change", refresh);
@@ -95,6 +108,7 @@
     function refresh() {
       output.innerHTML = formatMarkdown({
         markdown: input.value,
+        minDepth: parseInt(minDepth.value),
         maxDepth: parseInt(maxDepth.value),
         title: title.value,
         compact: compact.checked,

--- a/extend.go
+++ b/extend.go
@@ -32,6 +32,13 @@ type Extender struct {
 	// Defaults to "Table of Contents" if unspecified.
 	Title string
 
+	// MinDepth is the minimum depth of the table of contents.
+	// Headings with a level lower than the specified depth will be ignored.
+	// See the documentation for MinDepth for more information.
+	//
+	// Defaults to 0 (no limit) if unspecified.
+	MinDepth int
+
 	// MaxDepth is the maximum depth of the table of contents.
 	// Headings with a level greater than the specified depth will be ignored.
 	// See the documentation for MaxDepth for more information.
@@ -58,6 +65,7 @@ func (e *Extender) Extend(md goldmark.Markdown) {
 		parser.WithASTTransformers(
 			util.Prioritized(&Transformer{
 				Title:    e.Title,
+				MinDepth: e.MinDepth,
 				MaxDepth: e.MaxDepth,
 				ListID:   e.ListID,
 				Compact:  e.Compact,

--- a/inspect_test.go
+++ b/inspect_test.go
@@ -151,7 +151,31 @@ func TestInspect(t *testing.T) {
 			},
 		},
 		{
-			desc: "depth",
+			desc: "minDepth",
+			give: []string{
+				"# A",
+				"###### B",
+				"### C",
+				"##### D",
+				"## E",
+				"# F",
+				"# G",
+			},
+			opts: []InspectOption{MinDepth(3)},
+			want: Items{
+				item("", "",
+					item("", "",
+						item("", "",
+							item("", "",
+								item("", "",
+									item("B", "b")))),
+						item("C", "c",
+							item("", "",
+								item("D", "d"))))),
+			},
+		},
+		{
+			desc: "maxDepth",
 			give: []string{
 				"# A",
 				"###### B",
@@ -252,6 +276,9 @@ func TestInspectOption_String(t *testing.T) {
 		give InspectOption
 		want string
 	}{
+		{give: MinDepth(3), want: "MinDepth(3)"},
+		{give: MinDepth(0), want: "MinDepth(0)"},
+		{give: MinDepth(-1), want: "MinDepth(-1)"},
 		{give: MaxDepth(3), want: "MaxDepth(3)"},
 		{give: MaxDepth(0), want: "MaxDepth(0)"},
 		{give: MaxDepth(-1), want: "MaxDepth(-1)"},

--- a/inspect_test.go
+++ b/inspect_test.go
@@ -175,6 +175,24 @@ func TestInspect(t *testing.T) {
 			},
 		},
 		{
+			desc: "minDepth/compact",
+			give: []string{
+				"# A",
+				"###### B",
+				"### C",
+				"##### D",
+				"## E",
+				"# F",
+				"# G",
+			},
+			opts: []InspectOption{MinDepth(3), Compact(true)},
+			want: Items{
+				item("B", "b"),
+				item("C", "c",
+					item("D", "d")),
+			},
+		},
+		{
 			desc: "maxDepth",
 			give: []string{
 				"# A",

--- a/integration_test.go
+++ b/integration_test.go
@@ -25,6 +25,7 @@ func TestIntegration(t *testing.T) {
 		Title  string `yaml:"title"`
 		ListID string `yaml:"listID"`
 
+		MinDepth int  `yaml:"minDepth"`
 		MaxDepth int  `yaml:"maxDepth"`
 		Compact  bool `yaml:"compact"`
 	}
@@ -38,6 +39,7 @@ func TestIntegration(t *testing.T) {
 			md := goldmark.New(
 				goldmark.WithExtensions(&toc.Extender{
 					Title:    tt.Title,
+					MinDepth: tt.MinDepth,
 					MaxDepth: tt.MaxDepth,
 					Compact:  tt.Compact,
 					ListID:   tt.ListID,

--- a/testdata/tests.yaml
+++ b/testdata/tests.yaml
@@ -129,6 +129,34 @@
     <h2 id="bar">Bar</h2>
     <h1 id="baz">Baz</h1>
     <h3 id="qux">Qux</h3>
+- desc: minDepth
+  minDepth: 3
+  give: |
+    # Foo
+
+    ## Bar
+
+    # Baz
+
+    ### Qux
+  want: |
+    <h1>Table of Contents</h1>
+    <ul>
+    <li>
+    <ul>
+    <li>
+    <ul>
+    <li>
+    <a href="#qux">Qux</a></li>
+    </ul>
+    </li>
+    </ul>
+    </li>
+    </ul>
+    <h1 id="foo">Foo</h1>
+    <h2 id="bar">Bar</h2>
+    <h1 id="baz">Baz</h1>
+    <h3 id="qux">Qux</h3>
 
 - desc: list id
   listID: my-toc

--- a/transform.go
+++ b/transform.go
@@ -30,6 +30,10 @@ type Transformer struct {
 	// Defaults to "Table of Contents" if unspecified.
 	Title string
 
+	// MinDepth is the minimum depth of the table of contents.
+	// See the documentation for MinDepth for more information.
+	MinDepth int
+
 	// MaxDepth is the maximum depth of the table of contents.
 	// See the documentation for MaxDepth for more information.
 	MaxDepth int
@@ -59,7 +63,7 @@ var _ parser.ASTTransformer = (*Transformer)(nil) // interface compliance
 // Errors encountered while transforming are ignored. For more fine-grained
 // control, use Inspect and transform the document manually.
 func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, _ parser.Context) {
-	toc, err := Inspect(doc, reader.Source(), MaxDepth(t.MaxDepth), Compact(t.Compact))
+	toc, err := Inspect(doc, reader.Source(), MinDepth(t.MinDepth), MaxDepth(t.MaxDepth), Compact(t.Compact))
 	if err != nil {
 		// There are currently no scenarios under which Inspect
 		// returns an error but we have to account for it anyway.


### PR DESCRIPTION
Adds a new 'MinDepth' option.
This option provides the ability to restrict the minimum header depth to include in the toc.

Adds entries to the README and an option to the demo playground for the new feature.

Testing:
Besides hand-written test cases, rapid-based property tests were added to verify that the resulting TOC contains all headings.

Resolves #40