### PR TITLE
Add IDs to TOC Title, support changing it

### DIFF
--- a/.changes/unreleased/Added-20231124-135030.yaml
+++ b/.changes/unreleased/Added-20231124-135030.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add a HeadingID option to specify a custom ID for the Table of Contents heading.
+time: 2023-11-24T13:50:30.526544-08:00

--- a/.changes/unreleased/Changed-20231124-134949.yaml
+++ b/.changes/unreleased/Changed-20231124-134949.yaml
@@ -1,0 +1,4 @@
+kind: Changed
+body: Table of Contents heading now automatically gets an ID if the Parser was given
+  an IDs generator.
+time: 2023-11-24T13:49:49.286533-08:00

--- a/extend.go
+++ b/extend.go
@@ -51,6 +51,11 @@ type Extender struct {
 	// See the documentation for Transformer.ListID for more information.
 	ListID string
 
+	// HeadingID is the id for the Title heading rendered in the HTML.
+	//
+	// See the documentation for Transformer.HeadingID for more information.
+	HeadingID string
+
 	// Compact controls whether empty items should be removed
 	// from the table of contents.
 	//
@@ -64,11 +69,12 @@ func (e *Extender) Extend(md goldmark.Markdown) {
 	md.Parser().AddOptions(
 		parser.WithASTTransformers(
 			util.Prioritized(&Transformer{
-				Title:    e.Title,
-				MinDepth: e.MinDepth,
-				MaxDepth: e.MaxDepth,
-				ListID:   e.ListID,
-				Compact:  e.Compact,
+				Title:     e.Title,
+				MinDepth:  e.MinDepth,
+				MaxDepth:  e.MaxDepth,
+				ListID:    e.ListID,
+				HeadingID: e.HeadingID,
+				Compact:   e.Compact,
 			}, 100),
 		),
 	)

--- a/integration_test.go
+++ b/integration_test.go
@@ -19,11 +19,12 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	var tests []struct {
-		Desc   string `yaml:"desc"`
-		Give   string `yaml:"give"`
-		Want   string `yaml:"want"`
-		Title  string `yaml:"title"`
-		ListID string `yaml:"listID"`
+		Desc      string `yaml:"desc"`
+		Give      string `yaml:"give"`
+		Want      string `yaml:"want"`
+		Title     string `yaml:"title"`
+		ListID    string `yaml:"listID"`
+		HeadingID string `yaml:"headingID"`
 
 		MinDepth int  `yaml:"minDepth"`
 		MaxDepth int  `yaml:"maxDepth"`
@@ -38,11 +39,12 @@ func TestIntegration(t *testing.T) {
 
 			md := goldmark.New(
 				goldmark.WithExtensions(&toc.Extender{
-					Title:    tt.Title,
-					MinDepth: tt.MinDepth,
-					MaxDepth: tt.MaxDepth,
-					Compact:  tt.Compact,
-					ListID:   tt.ListID,
+					Title:     tt.Title,
+					MinDepth:  tt.MinDepth,
+					MaxDepth:  tt.MaxDepth,
+					Compact:   tt.Compact,
+					ListID:    tt.ListID,
+					HeadingID: tt.HeadingID,
 				}),
 				goldmark.WithParserOptions(parser.WithAutoHeadingID()),
 			)

--- a/testdata/tests.yaml
+++ b/testdata/tests.yaml
@@ -10,7 +10,7 @@
 
     World
   want: |
-    <h1>Table of Contents</h1>
+    <h1 id="table-of-contents">Table of Contents</h1>
     <ul>
     <li>
     <a href="#hello">Hello</a></li>
@@ -28,7 +28,7 @@
 
     ### Qux
   want: |
-    <h1>Table of Contents</h1>
+    <h1 id="table-of-contents">Table of Contents</h1>
     <ul>
     <li>
     <a href="#foo">Foo</a><ul>
@@ -58,7 +58,7 @@
 
     ## Bar\-Baz
   want: |
-    <h1>Table of Contents</h1>
+    <h1 id="table-of-contents">Table of Contents</h1>
     <ul>
     <li>
     <a href="#foo-bar">Foo-Bar</a><ul>
@@ -74,7 +74,7 @@
   give: |
     # Foo\\\-Bar
   want: |
-    <h1>Table of Contents</h1>
+    <h1 id="table-of-contents">Table of Contents</h1>
     <ul>
     <li>
     <a href="#foo-bar">Foo\-Bar</a></li>
@@ -85,7 +85,7 @@
   give: |
     # **Formatted** `header`
   want: |
-    <h1>Table of Contents</h1>
+    <h1 id="table-of-contents">Table of Contents</h1>
     <ul>
     <li>
     <a href="#formatted-header">Formatted header</a></li>
@@ -99,7 +99,7 @@
 
     World
   want: |
-    <h1>Contents</h1>
+    <h1 id="contents">Contents</h1>
     <ul>
     <li>
     <a href="#hello">Hello</a></li>
@@ -118,7 +118,7 @@
 
     ### Qux
   want: |
-    <h1>Table of Contents</h1>
+    <h1 id="table-of-contents">Table of Contents</h1>
     <ul>
     <li>
     <a href="#foo">Foo</a></li>
@@ -140,7 +140,7 @@
 
     ### Qux
   want: |
-    <h1>Table of Contents</h1>
+    <h1 id="table-of-contents">Table of Contents</h1>
     <ul>
     <li>
     <ul>
@@ -165,7 +165,7 @@
 
     # World
   want: |
-    <h1>Table of Contents</h1>
+    <h1 id="table-of-contents">Table of Contents</h1>
     <ul id="my-toc">
     <li>
     <a href="#hello">Hello</a></li>
@@ -181,7 +181,7 @@
   give: |
     ### h3
   want: |
-    <h1>Table of Contents</h1>
+    <h1 id="table-of-contents">Table of Contents</h1>
     <ul>
     <li>
     <a href="#h3">h3</a></li>
@@ -194,7 +194,7 @@
     # h1
     ### h3
   want: |
-    <h1>Table of Contents</h1>
+    <h1 id="table-of-contents">Table of Contents</h1>
     <ul>
     <li>
     <a href="#h1">h1</a><ul>
@@ -205,3 +205,38 @@
     </ul>
     <h1 id="h1">h1</h1>
     <h3 id="h3">h3</h3>
+
+- desc: custom heading ID
+  headingID: toc-title
+  give: |
+    # Foo
+
+    ## Bar
+
+    # Baz
+
+    ### Qux
+  want: |
+    <h1 id="toc-title">Table of Contents</h1>
+    <ul>
+    <li>
+    <a href="#foo">Foo</a><ul>
+    <li>
+    <a href="#bar">Bar</a></li>
+    </ul>
+    </li>
+    <li>
+    <a href="#baz">Baz</a><ul>
+    <li>
+    <ul>
+    <li>
+    <a href="#qux">Qux</a></li>
+    </ul>
+    </li>
+    </ul>
+    </li>
+    </ul>
+    <h1 id="foo">Foo</h1>
+    <h2 id="bar">Bar</h2>
+    <h1 id="baz">Baz</h1>
+    <h3 id="qux">Qux</h3>


### PR DESCRIPTION
Previously, the title we generated above the TOC did not have an ID.
With this change, users can supply an ID for these,
and if one wasn't supplied, but a Parser.IDs is available,
we'll automatically generate and use one.

Resolves #49
