### PR TITLE
Define title heading depth

### DIFF
--- a/.changes/unreleased/Added-20240212-210804.yaml
+++ b/.changes/unreleased/Added-20240212-210804.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: >-
+  {Extender, Transformer}: Add TitleDepth field to change the level of the Table of Contents heading.
+time: 2024-02-12T21:08:04.915706-08:00

--- a/extend.go
+++ b/extend.go
@@ -32,6 +32,10 @@ type Extender struct {
 	// Defaults to "Table of Contents" if unspecified.
 	Title string
 
+	// TitleDepth is the heading depth for the Title.
+	// Defaults to 1 (<h1>) if unspecified.
+	TitleDepth int
+
 	// MinDepth is the minimum depth of the table of contents.
 	// Headings with a level lower than the specified depth will be ignored.
 	// See the documentation for MinDepth for more information.
@@ -69,12 +73,13 @@ func (e *Extender) Extend(md goldmark.Markdown) {
 	md.Parser().AddOptions(
 		parser.WithASTTransformers(
 			util.Prioritized(&Transformer{
-				Title:    e.Title,
-				MinDepth: e.MinDepth,
-				MaxDepth: e.MaxDepth,
-				ListID:   e.ListID,
-				TitleID:  e.TitleID,
-				Compact:  e.Compact,
+				Title:      e.Title,
+				TitleDepth: e.TitleDepth,
+				MinDepth:   e.MinDepth,
+				MaxDepth:   e.MaxDepth,
+				ListID:     e.ListID,
+				TitleID:    e.TitleID,
+				Compact:    e.Compact,
 			}, 100),
 		),
 	)

--- a/integration_test.go
+++ b/integration_test.go
@@ -19,12 +19,13 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	var tests []struct {
-		Desc    string `yaml:"desc"`
-		Give    string `yaml:"give"`
-		Want    string `yaml:"want"`
-		Title   string `yaml:"title"`
-		ListID  string `yaml:"listID"`
-		TitleID string `yaml:"titleID"`
+		Desc       string `yaml:"desc"`
+		Give       string `yaml:"give"`
+		Want       string `yaml:"want"`
+		Title      string `yaml:"title"`
+		TitleDepth int    `yaml:"titleDepth"`
+		ListID     string `yaml:"listID"`
+		TitleID    string `yaml:"titleID"`
 
 		MinDepth int  `yaml:"minDepth"`
 		MaxDepth int  `yaml:"maxDepth"`
@@ -39,12 +40,13 @@ func TestIntegration(t *testing.T) {
 
 			md := goldmark.New(
 				goldmark.WithExtensions(&toc.Extender{
-					Title:    tt.Title,
-					MinDepth: tt.MinDepth,
-					MaxDepth: tt.MaxDepth,
-					Compact:  tt.Compact,
-					ListID:   tt.ListID,
-					TitleID:  tt.TitleID,
+					Title:      tt.Title,
+					TitleDepth: tt.TitleDepth,
+					MinDepth:   tt.MinDepth,
+					MaxDepth:   tt.MaxDepth,
+					Compact:    tt.Compact,
+					ListID:     tt.ListID,
+					TitleID:    tt.TitleID,
 				}),
 				goldmark.WithParserOptions(parser.WithAutoHeadingID()),
 			)

--- a/testdata/tests.yaml
+++ b/testdata/tests.yaml
@@ -240,3 +240,75 @@
     <h2 id="bar">Bar</h2>
     <h1 id="baz">Baz</h1>
     <h3 id="qux">Qux</h3>
+
+# From: https://github.com/abhinav/goldmark-toc/issues/61
+- desc: custom title depth of 2
+  titleDepth: 2
+  give: |
+    # Foo
+
+    ## Bar
+
+    # Baz
+
+    ### Qux
+  want: |
+    <h2 id="table-of-contents">Table of Contents</h2>
+    <ul>
+    <li>
+    <a href="#foo">Foo</a><ul>
+    <li>
+    <a href="#bar">Bar</a></li>
+    </ul>
+    </li>
+    <li>
+    <a href="#baz">Baz</a><ul>
+    <li>
+    <ul>
+    <li>
+    <a href="#qux">Qux</a></li>
+    </ul>
+    </li>
+    </ul>
+    </li>
+    </ul>
+    <h1 id="foo">Foo</h1>
+    <h2 id="bar">Bar</h2>
+    <h1 id="baz">Baz</h1>
+    <h3 id="qux">Qux</h3>
+
+# From: https://github.com/abhinav/goldmark-toc/issues/61
+# - desc: custom title depth of 7
+#   titleDepth: 7
+#   give: |
+#     # Foo
+
+#     ## Bar
+
+#     # Baz
+
+#     ### Qux
+#   want: |
+#     <h6 id="table-of-contents">Table of Contents</h6>
+#     <ul>
+#     <li>
+#     <a href="#foo">Foo</a><ul>
+#     <li>
+#     <a href="#bar">Bar</a></li>
+#     </ul>
+#     </li>
+#     <li>
+#     <a href="#baz">Baz</a><ul>
+#     <li>
+#     <ul>
+#     <li>
+#     <a href="#qux">Qux</a></li>
+#     </ul>
+#     </li>
+#     </ul>
+#     </li>
+#     </ul>
+#     <h1 id="foo">Foo</h1>
+#     <h2 id="bar">Bar</h2>
+#     <h1 id="baz">Baz</h1>
+#     <h3 id="qux">Qux</h3>

--- a/testdata/tests.yaml
+++ b/testdata/tests.yaml
@@ -277,38 +277,37 @@
     <h1 id="baz">Baz</h1>
     <h3 id="qux">Qux</h3>
 
-# From: https://github.com/abhinav/goldmark-toc/issues/61
-# - desc: custom title depth of 7
-#   titleDepth: 7
-#   give: |
-#     # Foo
+- desc: title depth > 6
+  titleDepth: 7
+  give: |
+    # Foo
 
-#     ## Bar
+    ## Bar
 
-#     # Baz
+    # Baz
 
-#     ### Qux
-#   want: |
-#     <h6 id="table-of-contents">Table of Contents</h6>
-#     <ul>
-#     <li>
-#     <a href="#foo">Foo</a><ul>
-#     <li>
-#     <a href="#bar">Bar</a></li>
-#     </ul>
-#     </li>
-#     <li>
-#     <a href="#baz">Baz</a><ul>
-#     <li>
-#     <ul>
-#     <li>
-#     <a href="#qux">Qux</a></li>
-#     </ul>
-#     </li>
-#     </ul>
-#     </li>
-#     </ul>
-#     <h1 id="foo">Foo</h1>
-#     <h2 id="bar">Bar</h2>
-#     <h1 id="baz">Baz</h1>
-#     <h3 id="qux">Qux</h3>
+    ### Qux
+  want: |
+    <h6 id="table-of-contents">Table of Contents</h6>
+    <ul>
+    <li>
+    <a href="#foo">Foo</a><ul>
+    <li>
+    <a href="#bar">Bar</a></li>
+    </ul>
+    </li>
+    <li>
+    <a href="#baz">Baz</a><ul>
+    <li>
+    <ul>
+    <li>
+    <a href="#qux">Qux</a></li>
+    </ul>
+    </li>
+    </ul>
+    </li>
+    </ul>
+    <h1 id="foo">Foo</h1>
+    <h2 id="bar">Bar</h2>
+    <h1 id="baz">Baz</h1>
+    <h3 id="qux">Qux</h3>

--- a/transform.go
+++ b/transform.go
@@ -8,6 +8,7 @@ import (
 
 const _defaultTitle = "Table of Contents"
 const _defaultTitleDepth = 1
+const _defaultMaxTitleDepth = 6
 
 // Transformer is a Goldmark AST transformer adds a TOC to the top of a
 // Markdown document.
@@ -106,6 +107,14 @@ func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, ctx parse
 	titleDepth := t.TitleDepth
 	if titleDepth == 0 {
 		titleDepth = _defaultTitleDepth
+	}
+
+	// Defaults to max title depth of 6
+	// if given TitleDepth > 6. Could also
+	// make sense to default to
+	// _defaultTitleDepth instead.
+	if titleDepth > _defaultMaxTitleDepth {
+		titleDepth = _defaultMaxTitleDepth
 	}
 
 	titleBytes := []byte(title)

--- a/transform.go
+++ b/transform.go
@@ -6,9 +6,13 @@ import (
 	"github.com/yuin/goldmark/text"
 )
 
-const _defaultTitle = "Table of Contents"
-const _defaultTitleDepth = 1
-const _defaultMaxTitleDepth = 6
+const (
+	_defaultTitle = "Table of Contents"
+
+	// Title depth is [1, 6] inclusive.
+	_defaultTitleDepth = 1
+	_maxTitleDepth     = 6
+)
 
 // Transformer is a Goldmark AST transformer adds a TOC to the top of a
 // Markdown document.
@@ -108,13 +112,8 @@ func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, ctx parse
 	if titleDepth < 1 {
 		titleDepth = _defaultTitleDepth
 	}
-
-	// Defaults to max title depth of 6
-	// if given TitleDepth > 6. Could also
-	// make sense to default to
-	// _defaultTitleDepth instead.
-	if titleDepth > _defaultMaxTitleDepth {
-		titleDepth = _defaultMaxTitleDepth
+	if titleDepth > _maxTitleDepth {
+		titleDepth = _maxTitleDepth
 	}
 
 	titleBytes := []byte(title)

--- a/transform.go
+++ b/transform.go
@@ -105,7 +105,7 @@ func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, ctx parse
 	}
 
 	titleDepth := t.TitleDepth
-	if titleDepth == 0 {
+	if titleDepth < 1 {
 		titleDepth = _defaultTitleDepth
 	}
 

--- a/transform.go
+++ b/transform.go
@@ -7,6 +7,7 @@ import (
 )
 
 const _defaultTitle = "Table of Contents"
+const _defaultTitleDepth = 1
 
 // Transformer is a Goldmark AST transformer adds a TOC to the top of a
 // Markdown document.
@@ -29,6 +30,10 @@ type Transformer struct {
 	// Title is the title of the table of contents section.
 	// Defaults to "Table of Contents" if unspecified.
 	Title string
+
+	// TitleDepth is the heading depth for the Title.
+	// Defaults to 1 (<h1>) if unspecified.
+	TitleDepth int
 
 	// MinDepth is the minimum depth of the table of contents.
 	// See the documentation for MinDepth for more information.
@@ -98,8 +103,13 @@ func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, ctx parse
 		title = _defaultTitle
 	}
 
+	titleDepth := t.TitleDepth
+	if titleDepth == 0 {
+		titleDepth = _defaultTitleDepth
+	}
+
 	titleBytes := []byte(title)
-	heading := ast.NewHeading(1)
+	heading := ast.NewHeading(titleDepth)
 	heading.AppendChild(heading, ast.NewString(titleBytes))
 	if id := t.TitleID; len(id) > 0 {
 		heading.SetAttributeString("id", []byte(id))

--- a/transform_test.go
+++ b/transform_test.go
@@ -61,3 +61,95 @@ func TestTransformer(t *testing.T) {
 		})
 	}
 }
+
+func TestTransformerWithTitleDepth(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(strings.Join([]string{
+		"# Hey",
+		"## Now",
+		"# Then",
+		"### There",
+		"## Now",
+	}, "\n") + "\n")
+
+	tests := []struct {
+		desc           string
+		giveTitleDepth int
+		wantTitleDepth int
+	}{
+		{
+			desc:           "default title depth",
+			wantTitleDepth: _defaultTitleDepth,
+		},
+		{
+			desc:           "title depth 0",
+			giveTitleDepth: 0,
+			wantTitleDepth: 1,
+		},
+		{
+			desc:           "title depth 1",
+			giveTitleDepth: 1,
+			wantTitleDepth: 1,
+		},
+		{
+			desc:           "title depth 2",
+			giveTitleDepth: 2,
+			wantTitleDepth: 2,
+		},
+		{
+			desc:           "title depth 3",
+			giveTitleDepth: 3,
+			wantTitleDepth: 3,
+		},
+		{
+			desc:           "title depth 4",
+			giveTitleDepth: 4,
+			wantTitleDepth: 4,
+		},
+		{
+			desc:           "title depth 5",
+			giveTitleDepth: 5,
+			wantTitleDepth: 5,
+		},
+		{
+			desc:           "title depth 6",
+			giveTitleDepth: 6,
+			wantTitleDepth: 6,
+		},
+		{
+			desc:           "title depth 7",
+			giveTitleDepth: 7,
+			wantTitleDepth: 6,
+		},
+		{
+			desc:           "title depth 255",
+			giveTitleDepth: 255,
+			wantTitleDepth: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // for t.Parallel
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			doc := parser.NewParser(
+				parser.WithInlineParsers(parser.DefaultInlineParsers()...),
+				parser.WithBlockParsers(parser.DefaultBlockParsers()...),
+				parser.WithAutoHeadingID(),
+				parser.WithASTTransformers(
+					util.Prioritized(&Transformer{
+						TitleDepth: tt.giveTitleDepth,
+					}, 100),
+				),
+			).Parse(text.NewReader(src))
+
+			// Should definitely still be a heading
+			heading, ok := doc.FirstChild().(*ast.Heading)
+
+			require.True(t, ok, "first child must be a heading, got %T", doc.FirstChild())
+			assert.Equal(t, tt.wantTitleDepth, heading.Level, "level mismatch")
+		})
+	}
+}

--- a/transform_test.go
+++ b/transform_test.go
@@ -62,6 +62,7 @@ func TestTransformer(t *testing.T) {
 	}
 }
 
+// From: https://github.com/abhinav/goldmark-toc/issues/61
 func TestTransformerWithTitleDepth(t *testing.T) {
 	t.Parallel()
 

--- a/transform_test.go
+++ b/transform_test.go
@@ -128,6 +128,11 @@ func TestTransformerWithTitleDepth(t *testing.T) {
 			giveTitleDepth: 255,
 			wantTitleDepth: 6,
 		},
+		{
+			desc:           "title depth -1",
+			giveTitleDepth: -1,
+			wantTitleDepth: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/transform_test.go
+++ b/transform_test.go
@@ -1,6 +1,7 @@
 package toc
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -74,65 +75,40 @@ func TestTransformerWithTitleDepth(t *testing.T) {
 		"## Now",
 	}, "\n") + "\n")
 
-	tests := []struct {
-		desc           string
-		giveTitleDepth int
-		wantTitleDepth int
-	}{
+	type testCase struct {
+		desc      string
+		giveDepth int
+		wantDepth int
+	}
+
+	tests := []testCase{
 		{
-			desc:           "default title depth",
-			wantTitleDepth: _defaultTitleDepth,
+			desc:      "default",
+			wantDepth: _defaultTitleDepth,
 		},
 		{
-			desc:           "title depth 0",
-			giveTitleDepth: 0,
-			wantTitleDepth: 1,
+			desc:      "< 1",
+			giveDepth: -1,
+			wantDepth: 1,
 		},
 		{
-			desc:           "title depth 1",
-			giveTitleDepth: 1,
-			wantTitleDepth: 1,
+			desc:      "> 6",
+			giveDepth: 7,
+			wantDepth: 6,
 		},
 		{
-			desc:           "title depth 2",
-			giveTitleDepth: 2,
-			wantTitleDepth: 2,
+			desc:      "absurd",
+			giveDepth: 130931,
+			wantDepth: 6,
 		},
-		{
-			desc:           "title depth 3",
-			giveTitleDepth: 3,
-			wantTitleDepth: 3,
-		},
-		{
-			desc:           "title depth 4",
-			giveTitleDepth: 4,
-			wantTitleDepth: 4,
-		},
-		{
-			desc:           "title depth 5",
-			giveTitleDepth: 5,
-			wantTitleDepth: 5,
-		},
-		{
-			desc:           "title depth 6",
-			giveTitleDepth: 6,
-			wantTitleDepth: 6,
-		},
-		{
-			desc:           "title depth 7",
-			giveTitleDepth: 7,
-			wantTitleDepth: 6,
-		},
-		{
-			desc:           "title depth 255",
-			giveTitleDepth: 255,
-			wantTitleDepth: 6,
-		},
-		{
-			desc:           "title depth -1",
-			giveTitleDepth: -1,
-			wantTitleDepth: 1,
-		},
+	}
+
+	for i := _defaultTitleDepth; i <= _maxTitleDepth; i++ {
+		tests = append(tests, testCase{
+			desc:      fmt.Sprintf("valid/%d", i),
+			giveDepth: i,
+			wantDepth: i,
+		})
 	}
 
 	for _, tt := range tests {
@@ -146,7 +122,7 @@ func TestTransformerWithTitleDepth(t *testing.T) {
 				parser.WithAutoHeadingID(),
 				parser.WithASTTransformers(
 					util.Prioritized(&Transformer{
-						TitleDepth: tt.giveTitleDepth,
+						TitleDepth: tt.giveDepth,
 					}, 100),
 				),
 			).Parse(text.NewReader(src))
@@ -155,7 +131,7 @@ func TestTransformerWithTitleDepth(t *testing.T) {
 			heading, ok := doc.FirstChild().(*ast.Heading)
 
 			require.True(t, ok, "first child must be a heading, got %T", doc.FirstChild())
-			assert.Equal(t, tt.wantTitleDepth, heading.Level, "level mismatch")
+			assert.Equal(t, tt.wantDepth, heading.Level, "level mismatch")
 		})
 	}
 }


### PR DESCRIPTION
- Added TitleDepth property to Extender.
- Added TitleDepth property to Transformer
- Added _defaultTitleDepth and _defaultMaxTitleDepth consts to Extender module
- Includes guards against titleDepth <1 && TitleDepth > 6
  - Defaults to depth of 1 if < 1, 6 if > 6
- Added tests to transform_test.go
- Added integration tests

Note: For some reason, I couldn't get the integration test for a HeadingDepth > 6 to work, though the output appears to be what was expected. The diff is different somewhere that I can't pin down.

Happy to make changes & update documentation as needed.

Resolves #61