### PR TITLE
upgrade goldmark, handle Node.Text deprecation

### DIFF
--- a/.changes/unreleased/Changed-20250202-111731.yaml
+++ b/.changes/unreleased/Changed-20250202-111731.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'goldmark: Raise minimum version to v1.7.8. This version of goldmark deprecates `Node.Text`.'
+time: 2025-02-02T11:17:31.483735-08:00

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/stretchr/testify v1.9.0
-	github.com/yuin/goldmark v1.7.7
+	github.com/yuin/goldmark v1.7.8
 	gopkg.in/yaml.v3 v3.0.1
 	pgregory.net/rapid v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/yuin/goldmark v1.7.7 h1:5m9rrB1sW3JUMToKFQfb+FGt1U7r57IHu5GrYrG2nqU=
-github.com/yuin/goldmark v1.7.7/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
+github.com/yuin/goldmark v1.7.8 h1:iERMLn0/QJeHFhxSt3p6PeN9mGnvIKSpG9YYorDMnic=
+github.com/yuin/goldmark v1.7.8/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/render_test.go
+++ b/render_test.go
@@ -63,7 +63,7 @@ func (tt *listItem) Match(t *testing.T, got *ast.ListItem) {
 			}
 		}
 
-		assert.Equal(t, want, string(child.Text(nil /* src */)))
+		assert.Equal(t, want, string(nodeText(nil /* src */, child)))
 		child = child.NextSibling()
 	}
 

--- a/transform_test.go
+++ b/transform_test.go
@@ -58,7 +58,8 @@ func TestTransformer(t *testing.T) {
 
 			heading, ok := doc.FirstChild().(*ast.Heading)
 			require.True(t, ok, "first child must be a heading, got %T", doc.FirstChild())
-			assert.Equal(t, tt.wantTitle, string(heading.Text(src)), "title mismatch")
+			gotTitle := nodeText(src, heading)
+			assert.Equal(t, tt.wantTitle, string(gotTitle), "title mismatch")
 		})
 	}
 }


### PR DESCRIPTION
Node.Text has been deprecated and callers must traverse the node tree
to get the required text output.