### PR TITLE
Use semantic <p> for TOC title and add aria-label accessibility support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ You can specify an ID for the title heading with the `TitleID` option.
 
 #### Hiding the title
 
-If you don't want a title heading rendered at all
-(e.g., to reserve `<h1>` for the main page title),
+If you don't want a title rendered at all,
 set the `HideTitle` field to `true`.
 
 ```go
@@ -95,13 +94,36 @@ set the `HideTitle` field to `true`.
 }
 ```
 
-This will render only the TOC list without a heading:
+This will render only the TOC list without a title:
 
 ```html
 <ul>
   <li><a href="#section-1">Section 1</a></li>
   <!-- ... -->
 </ul>
+```
+
+When `HideTitle` is combined with `ContainerElement`,
+an `aria-label` attribute is automatically added to the container
+for accessibility. The `aria-label` uses the `Title` value
+(or the default "Table of Contents"):
+
+```go
+&toc.Extender{
+  Title:            "Navigation",
+  HideTitle:        true,
+  ContainerElement: "nav",
+}
+```
+
+This will render:
+
+```html
+<nav aria-label="Navigation">
+<ul>
+  <!-- ... -->
+</ul>
+</nav>
 ```
 
 #### Adding an ID
@@ -139,7 +161,7 @@ This will render:
 
 ```html
 <nav>
-<h1>Table of Contents</h1>
+<p>Table of Contents</p>
 <ul>
   <!-- ... -->
 </ul>
@@ -161,7 +183,7 @@ This will render:
 
 ```html
 <nav id="table-of-contents" class="toc-nav">
-<h1>Table of Contents</h1>
+<p>Table of Contents</p>
 <ul>
   <!-- ... -->
 </ul>
@@ -178,10 +200,10 @@ You can combine `HideTitle` with container options:
 }
 ```
 
-This will render:
+This will render (with `aria-label` for accessibility):
 
 ```html
-<nav class="toc">
+<nav class="toc" aria-label="Table of Contents">
 <ul>
   <!-- ... -->
 </ul>
@@ -266,7 +288,7 @@ As with the previous example, this enables `parser.WithAutoHeadingID` to get
 auto-generated heading IDs.
 
 The `Transformer` supports the same options as `Extender`:
-`Title`, `TitleDepth`, `TitleID`, `ListID`, `MinDepth`, `MaxDepth`, `Compact`,
+`Title`, `TitleID`, `ListID`, `MinDepth`, `MaxDepth`, `Compact`,
 `HideTitle`, `ContainerElement`, `ContainerClass`, and `ContainerID`.
 
 ### Manual

--- a/README.md
+++ b/README.md
@@ -83,6 +83,27 @@ You can specify an ID for the title heading with the `TitleID` option.
 }
 ```
 
+#### Hiding the title
+
+If you don't want a title heading rendered at all
+(e.g., to reserve `<h1>` for the main page title),
+set the `HideTitle` field to `true`.
+
+```go
+&toc.Extender{
+  HideTitle: true,
+}
+```
+
+This will render only the TOC list without a heading:
+
+```html
+<ul>
+  <li><a href="#section-1">Section 1</a></li>
+  <!-- ... -->
+</ul>
+```
+
 #### Adding an ID
 
 If you want the rendered HTML list to include an id,
@@ -100,6 +121,71 @@ This will render:
 <ul id="toc">
   <!-- ... -->
 </ul>
+```
+
+#### Wrapping in a container element
+
+If you want to wrap the TOC in a container element for easier styling
+or semantic HTML, use the `ContainerElement` field.
+Common values are `"nav"`, `"div"`, or `"aside"`.
+
+```go
+&toc.Extender{
+  ContainerElement: "nav",
+}
+```
+
+This will render:
+
+```html
+<nav>
+<h1>Table of Contents</h1>
+<ul>
+  <!-- ... -->
+</ul>
+</nav>
+```
+
+You can add a CSS class and/or ID to the container with
+`ContainerClass` and `ContainerID`:
+
+```go
+&toc.Extender{
+  ContainerElement: "nav",
+  ContainerClass:   "toc-nav",
+  ContainerID:      "table-of-contents",
+}
+```
+
+This will render:
+
+```html
+<nav id="table-of-contents" class="toc-nav">
+<h1>Table of Contents</h1>
+<ul>
+  <!-- ... -->
+</ul>
+</nav>
+```
+
+You can combine `HideTitle` with container options:
+
+```go
+&toc.Extender{
+  HideTitle:        true,
+  ContainerElement: "nav",
+  ContainerClass:   "toc",
+}
+```
+
+This will render:
+
+```html
+<nav class="toc">
+<ul>
+  <!-- ... -->
+</ul>
+</nav>
 ```
 
 #### Limiting the Table of Contents
@@ -178,6 +264,10 @@ parsed by this parser.
 
 As with the previous example, this enables `parser.WithAutoHeadingID` to get
 auto-generated heading IDs.
+
+The `Transformer` supports the same options as `Extender`:
+`Title`, `TitleDepth`, `TitleID`, `ListID`, `MinDepth`, `MaxDepth`, `Compact`,
+`HideTitle`, `ContainerElement`, `ContainerClass`, and `ContainerID`.
 
 ### Manual
 

--- a/extend.go
+++ b/extend.go
@@ -2,7 +2,10 @@ package toc
 
 import (
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/util"
 )
 
@@ -65,6 +68,54 @@ type Extender struct {
 	//
 	// See the documentation for Compact for more information.
 	Compact bool
+
+	// HideTitle controls whether the title heading is rendered.
+	// When set to true, the title (e.g., <h1>Table of Contents</h1>) is not rendered,
+	// and only the TOC list is output.
+	//
+	// This is useful when you want to reserve <h1> for the main page title
+	// or when you want to style the TOC differently.
+	//
+	// Defaults to false (title is shown).
+	HideTitle bool
+
+	// ContainerElement specifies the HTML element to wrap the TOC in.
+	// Common values are "nav", "div", "aside", etc.
+	//
+	// For example, if ContainerElement is "nav", the table of contents
+	// will be rendered as:
+	//
+	//	<nav>
+	//	  <h1>Table of Contents</h1>
+	//	  <ul>...</ul>
+	//	</nav>
+	//
+	// If ContainerElement is empty, no wrapper element is added.
+	ContainerElement string
+
+	// ContainerClass specifies the CSS class(es) for the container element.
+	// This is only used when ContainerElement is set.
+	//
+	// For example, if ContainerElement is "nav" and ContainerClass is "toc-nav",
+	// the table of contents will be rendered as:
+	//
+	//	<nav class="toc-nav">
+	//	  ...
+	//	</nav>
+	//
+	// Multiple classes can be specified separated by spaces.
+	ContainerClass string
+
+	// ContainerID specifies the ID for the container element.
+	// This is only used when ContainerElement is set.
+	//
+	// For example, if ContainerElement is "nav" and ContainerID is "table-of-contents",
+	// the table of contents will be rendered as:
+	//
+	//	<nav id="table-of-contents">
+	//	  ...
+	//	</nav>
+	ContainerID string
 }
 
 // Extend adds support for rendering a table of contents to the provided
@@ -73,14 +124,72 @@ func (e *Extender) Extend(md goldmark.Markdown) {
 	md.Parser().AddOptions(
 		parser.WithASTTransformers(
 			util.Prioritized(&Transformer{
-				Title:      e.Title,
-				TitleDepth: e.TitleDepth,
-				MinDepth:   e.MinDepth,
-				MaxDepth:   e.MaxDepth,
-				ListID:     e.ListID,
-				TitleID:    e.TitleID,
-				Compact:    e.Compact,
+				Title:            e.Title,
+				TitleDepth:       e.TitleDepth,
+				TitleID:          e.TitleID,
+				ListID:           e.ListID,
+				MinDepth:         e.MinDepth,
+				MaxDepth:         e.MaxDepth,
+				Compact:          e.Compact,
+				HideTitle:        e.HideTitle,
+				ContainerElement: e.ContainerElement,
+				ContainerClass:   e.ContainerClass,
+				ContainerID:      e.ContainerID,
 			}, 100),
 		),
 	)
+
+	// Always register the container node renderer.
+	// If ContainerElement is empty, the renderer simply won't be used,
+	// but it needs to be registered in case Transformer uses it.
+	md.Renderer().AddOptions(
+		renderer.WithNodeRenderers(
+			util.Prioritized(newContainerNodeRenderer(), 100),
+		),
+	)
+}
+
+// containerNodeRenderer renders containerNode as HTML.
+type containerNodeRenderer struct {
+	html.Config
+}
+
+// newContainerNodeRenderer returns a new renderer for containerNode.
+func newContainerNodeRenderer(opts ...html.Option) renderer.NodeRenderer {
+	r := &containerNodeRenderer{
+		Config: html.NewConfig(),
+	}
+	for _, opt := range opts {
+		opt.SetHTMLOption(&r.Config)
+	}
+	return r
+}
+
+// RegisterFuncs registers the render functions for containerNode.
+func (r *containerNodeRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindContainerNode, r.renderContainer)
+}
+
+func (r *containerNodeRenderer) renderContainer(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	n := node.(*containerNode)
+	if entering {
+		_, _ = w.WriteString("<")
+		_, _ = w.WriteString(n.element)
+		if n.id != "" {
+			_, _ = w.WriteString(` id="`)
+			_, _ = w.WriteString(n.id)
+			_, _ = w.WriteString(`"`)
+		}
+		if n.class != "" {
+			_, _ = w.WriteString(` class="`)
+			_, _ = w.WriteString(n.class)
+			_, _ = w.WriteString(`"`)
+		}
+		_, _ = w.WriteString(">\n")
+	} else {
+		_, _ = w.WriteString("</")
+		_, _ = w.WriteString(n.element)
+		_, _ = w.WriteString(">\n")
+	}
+	return ast.WalkContinue, nil
 }

--- a/extend.go
+++ b/extend.go
@@ -33,11 +33,8 @@ import (
 type Extender struct {
 	// Title is the title of the table of contents section.
 	// Defaults to "Table of Contents" if unspecified.
+	// The title is rendered as a <p> element.
 	Title string
-
-	// TitleDepth is the heading depth for the Title.
-	// Defaults to 1 (<h1>) if unspecified.
-	TitleDepth int
 
 	// MinDepth is the minimum depth of the table of contents.
 	// Headings with a level lower than the specified depth will be ignored.
@@ -58,7 +55,7 @@ type Extender struct {
 	// See the documentation for Transformer.ListID for more information.
 	ListID string
 
-	// TitleID is the id for the Title heading rendered in the HTML.
+	// TitleID is the id for the Title element rendered in the HTML.
 	//
 	// See the documentation for Transformer.TitleID for more information.
 	TitleID string
@@ -69,12 +66,13 @@ type Extender struct {
 	// See the documentation for Compact for more information.
 	Compact bool
 
-	// HideTitle controls whether the title heading is rendered.
-	// When set to true, the title (e.g., <h1>Table of Contents</h1>) is not rendered,
+	// HideTitle controls whether the title is rendered.
+	// When set to true, the title (e.g., <p>Table of Contents</p>) is not rendered,
 	// and only the TOC list is output.
 	//
-	// This is useful when you want to reserve <h1> for the main page title
-	// or when you want to style the TOC differently.
+	// When HideTitle is true and ContainerElement is set,
+	// an aria-label attribute with the title text is added to the container
+	// for accessibility.
 	//
 	// Defaults to false (title is shown).
 	HideTitle bool
@@ -86,7 +84,7 @@ type Extender struct {
 	// will be rendered as:
 	//
 	//	<nav>
-	//	  <h1>Table of Contents</h1>
+	//	  <p>Table of Contents</p>
 	//	  <ul>...</ul>
 	//	</nav>
 	//
@@ -125,7 +123,6 @@ func (e *Extender) Extend(md goldmark.Markdown) {
 		parser.WithASTTransformers(
 			util.Prioritized(&Transformer{
 				Title:            e.Title,
-				TitleDepth:       e.TitleDepth,
 				TitleID:          e.TitleID,
 				ListID:           e.ListID,
 				MinDepth:         e.MinDepth,
@@ -183,6 +180,11 @@ func (r *containerNodeRenderer) renderContainer(w util.BufWriter, source []byte,
 		if n.class != "" {
 			_, _ = w.WriteString(` class="`)
 			_, _ = w.WriteString(n.class)
+			_, _ = w.WriteString(`"`)
+		}
+		if n.ariaLabel != "" {
+			_, _ = w.WriteString(` aria-label="`)
+			_, _ = w.WriteString(n.ariaLabel)
 			_, _ = w.WriteString(`"`)
 		}
 		_, _ = w.WriteString(">\n")

--- a/integration_test.go
+++ b/integration_test.go
@@ -19,13 +19,12 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	var tests []struct {
-		Desc       string `yaml:"desc"`
-		Give       string `yaml:"give"`
-		Want       string `yaml:"want"`
-		Title      string `yaml:"title"`
-		TitleDepth int    `yaml:"titleDepth"`
-		ListID     string `yaml:"listID"`
-		TitleID    string `yaml:"titleID"`
+		Desc    string `yaml:"desc"`
+		Give    string `yaml:"give"`
+		Want    string `yaml:"want"`
+		Title   string `yaml:"title"`
+		ListID  string `yaml:"listID"`
+		TitleID string `yaml:"titleID"`
 
 		MinDepth int  `yaml:"minDepth"`
 		MaxDepth int  `yaml:"maxDepth"`
@@ -40,13 +39,12 @@ func TestIntegration(t *testing.T) {
 
 			md := goldmark.New(
 				goldmark.WithExtensions(&toc.Extender{
-					Title:      tt.Title,
-					TitleDepth: tt.TitleDepth,
-					MinDepth:   tt.MinDepth,
-					MaxDepth:   tt.MaxDepth,
-					Compact:    tt.Compact,
-					ListID:     tt.ListID,
-					TitleID:    tt.TitleID,
+					Title:    tt.Title,
+					MinDepth: tt.MinDepth,
+					MaxDepth: tt.MaxDepth,
+					Compact:  tt.Compact,
+					ListID:   tt.ListID,
+					TitleID:  tt.TitleID,
 				}),
 				goldmark.WithParserOptions(parser.WithAutoHeadingID()),
 			)

--- a/new_features_test.go
+++ b/new_features_test.go
@@ -1,0 +1,240 @@
+package toc_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"go.abhg.dev/goldmark/toc"
+)
+
+func TestHideTitle(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+# Section 1
+## Subsection 1.1
+# Section 2
+`)
+
+	tests := []struct {
+		name      string
+		hideTitle bool
+		wantTitle bool
+	}{
+		{
+			name:      "with title (default)",
+			hideTitle: false,
+			wantTitle: true,
+		},
+		{
+			name:      "without title",
+			hideTitle: true,
+			wantTitle: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			md := goldmark.New(
+				goldmark.WithParserOptions(parser.WithAutoHeadingID()),
+				goldmark.WithExtensions(&toc.Extender{
+					HideTitle: tt.hideTitle,
+				}),
+			)
+
+			var buf bytes.Buffer
+			if err := md.Convert(src, &buf); err != nil {
+				t.Fatalf("Convert failed: %v", err)
+			}
+
+			output := buf.String()
+			hasTitle := strings.Contains(output, "Table of Contents")
+
+			if hasTitle != tt.wantTitle {
+				t.Errorf("HideTitle=%v: got title present=%v, want %v\nOutput:\n%s",
+					tt.hideTitle, hasTitle, tt.wantTitle, output)
+			}
+		})
+	}
+}
+
+func TestContainerElement(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+# Section 1
+## Subsection 1.1
+`)
+
+	tests := []struct {
+		name             string
+		containerElement string
+		containerClass   string
+		containerID      string
+		wantContains     []string
+		wantNotContains  []string
+	}{
+		{
+			name:             "no container",
+			containerElement: "",
+			wantNotContains:  []string{"<nav", "</nav>", "<div", "</div>"},
+		},
+		{
+			name:             "nav container",
+			containerElement: "nav",
+			wantContains:     []string{"<nav>", "</nav>"},
+		},
+		{
+			name:             "nav container with class",
+			containerElement: "nav",
+			containerClass:   "toc-nav",
+			wantContains:     []string{`<nav class="toc-nav">`, "</nav>"},
+		},
+		{
+			name:             "nav container with id",
+			containerElement: "nav",
+			containerID:      "table-of-contents",
+			wantContains:     []string{`<nav id="table-of-contents">`, "</nav>"},
+		},
+		{
+			name:             "nav container with class and id",
+			containerElement: "nav",
+			containerClass:   "toc-nav",
+			containerID:      "table-of-contents",
+			wantContains:     []string{`id="table-of-contents"`, `class="toc-nav"`, "</nav>"},
+		},
+		{
+			name:             "div container",
+			containerElement: "div",
+			containerClass:   "toc-wrapper",
+			wantContains:     []string{`<div class="toc-wrapper">`, "</div>"},
+		},
+		{
+			name:             "aside container",
+			containerElement: "aside",
+			wantContains:     []string{"<aside>", "</aside>"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			md := goldmark.New(
+				goldmark.WithParserOptions(parser.WithAutoHeadingID()),
+				goldmark.WithExtensions(&toc.Extender{
+					ContainerElement: tt.containerElement,
+					ContainerClass:   tt.containerClass,
+					ContainerID:      tt.containerID,
+				}),
+			)
+
+			var buf bytes.Buffer
+			if err := md.Convert(src, &buf); err != nil {
+				t.Fatalf("Convert failed: %v", err)
+			}
+
+			output := buf.String()
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(output, want) {
+					t.Errorf("Output should contain %q but doesn't.\nOutput:\n%s", want, output)
+				}
+			}
+
+			for _, notWant := range tt.wantNotContains {
+				if strings.Contains(output, notWant) {
+					t.Errorf("Output should not contain %q but does.\nOutput:\n%s", notWant, output)
+				}
+			}
+		})
+	}
+}
+
+func TestHideTitleWithContainer(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+# Section 1
+## Subsection 1.1
+`)
+
+	md := goldmark.New(
+		goldmark.WithParserOptions(parser.WithAutoHeadingID()),
+		goldmark.WithExtensions(&toc.Extender{
+			HideTitle:        true,
+			ContainerElement: "nav",
+			ContainerClass:   "toc",
+		}),
+	)
+
+	var buf bytes.Buffer
+	if err := md.Convert(src, &buf); err != nil {
+		t.Fatalf("Convert failed: %v", err)
+	}
+
+	output := buf.String()
+
+	// Should have nav container
+	if !strings.Contains(output, `<nav class="toc">`) {
+		t.Errorf("Output should contain nav container.\nOutput:\n%s", output)
+	}
+
+	// Should NOT have "Table of Contents" title
+	if strings.Contains(output, "Table of Contents") {
+		t.Errorf("Output should not contain title when HideTitle=true.\nOutput:\n%s", output)
+	}
+
+	// Should still have the TOC list
+	if !strings.Contains(output, "<ul>") {
+		t.Errorf("Output should still contain the TOC list.\nOutput:\n%s", output)
+	}
+}
+
+func TestContainerWithCustomTitle(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+# Section 1
+## Subsection 1.1
+`)
+
+	md := goldmark.New(
+		goldmark.WithParserOptions(parser.WithAutoHeadingID()),
+		goldmark.WithExtensions(&toc.Extender{
+			Title:            "Contents",
+			TitleDepth:       2,
+			ContainerElement: "nav",
+			ContainerID:      "toc",
+		}),
+	)
+
+	var buf bytes.Buffer
+	if err := md.Convert(src, &buf); err != nil {
+		t.Fatalf("Convert failed: %v", err)
+	}
+
+	output := buf.String()
+
+	// Should have nav container with ID
+	if !strings.Contains(output, `<nav id="toc">`) {
+		t.Errorf("Output should contain nav container with id.\nOutput:\n%s", output)
+	}
+
+	// Should have h2 title (TitleDepth=2)
+	if !strings.Contains(output, "<h2") {
+		t.Errorf("Output should contain h2 heading for title.\nOutput:\n%s", output)
+	}
+
+	// Should have custom title text
+	if !strings.Contains(output, "Contents") {
+		t.Errorf("Output should contain custom title 'Contents'.\nOutput:\n%s", output)
+	}
+}

--- a/testdata/tests.yaml
+++ b/testdata/tests.yaml
@@ -10,7 +10,7 @@
 
     World
   want: |
-    <h1 id="table-of-contents">Table of Contents</h1>
+    <p id="table-of-contents">Table of Contents</p>
     <ul>
     <li>
     <a href="#hello">Hello</a></li>
@@ -28,7 +28,7 @@
 
     ### Qux
   want: |
-    <h1 id="table-of-contents">Table of Contents</h1>
+    <p id="table-of-contents">Table of Contents</p>
     <ul>
     <li>
     <a href="#foo">Foo</a><ul>
@@ -58,7 +58,7 @@
 
     ## Bar\-Baz
   want: |
-    <h1 id="table-of-contents">Table of Contents</h1>
+    <p id="table-of-contents">Table of Contents</p>
     <ul>
     <li>
     <a href="#foo-bar">Foo-Bar</a><ul>
@@ -74,7 +74,7 @@
   give: |
     # Foo\\\-Bar
   want: |
-    <h1 id="table-of-contents">Table of Contents</h1>
+    <p id="table-of-contents">Table of Contents</p>
     <ul>
     <li>
     <a href="#foo-bar">Foo\-Bar</a></li>
@@ -85,7 +85,7 @@
   give: |
     # **Formatted** `header`
   want: |
-    <h1 id="table-of-contents">Table of Contents</h1>
+    <p id="table-of-contents">Table of Contents</p>
     <ul>
     <li>
     <a href="#formatted-header">Formatted header</a></li>
@@ -99,7 +99,7 @@
 
     World
   want: |
-    <h1 id="contents">Contents</h1>
+    <p id="contents">Contents</p>
     <ul>
     <li>
     <a href="#hello">Hello</a></li>
@@ -118,7 +118,7 @@
 
     ### Qux
   want: |
-    <h1 id="table-of-contents">Table of Contents</h1>
+    <p id="table-of-contents">Table of Contents</p>
     <ul>
     <li>
     <a href="#foo">Foo</a></li>
@@ -140,7 +140,7 @@
 
     ### Qux
   want: |
-    <h1 id="table-of-contents">Table of Contents</h1>
+    <p id="table-of-contents">Table of Contents</p>
     <ul>
     <li>
     <ul>
@@ -165,7 +165,7 @@
 
     # World
   want: |
-    <h1 id="table-of-contents">Table of Contents</h1>
+    <p id="table-of-contents">Table of Contents</p>
     <ul id="my-toc">
     <li>
     <a href="#hello">Hello</a></li>
@@ -181,7 +181,7 @@
   give: |
     ### h3
   want: |
-    <h1 id="table-of-contents">Table of Contents</h1>
+    <p id="table-of-contents">Table of Contents</p>
     <ul>
     <li>
     <a href="#h3">h3</a></li>
@@ -194,7 +194,7 @@
     # h1
     ### h3
   want: |
-    <h1 id="table-of-contents">Table of Contents</h1>
+    <p id="table-of-contents">Table of Contents</p>
     <ul>
     <li>
     <a href="#h1">h1</a><ul>
@@ -217,78 +217,7 @@
 
     ### Qux
   want: |
-    <h1 id="toc-title">Table of Contents</h1>
-    <ul>
-    <li>
-    <a href="#foo">Foo</a><ul>
-    <li>
-    <a href="#bar">Bar</a></li>
-    </ul>
-    </li>
-    <li>
-    <a href="#baz">Baz</a><ul>
-    <li>
-    <ul>
-    <li>
-    <a href="#qux">Qux</a></li>
-    </ul>
-    </li>
-    </ul>
-    </li>
-    </ul>
-    <h1 id="foo">Foo</h1>
-    <h2 id="bar">Bar</h2>
-    <h1 id="baz">Baz</h1>
-    <h3 id="qux">Qux</h3>
-
-# From: https://github.com/abhinav/goldmark-toc/issues/61
-- desc: custom title depth of 2
-  titleDepth: 2
-  give: |
-    # Foo
-
-    ## Bar
-
-    # Baz
-
-    ### Qux
-  want: |
-    <h2 id="table-of-contents">Table of Contents</h2>
-    <ul>
-    <li>
-    <a href="#foo">Foo</a><ul>
-    <li>
-    <a href="#bar">Bar</a></li>
-    </ul>
-    </li>
-    <li>
-    <a href="#baz">Baz</a><ul>
-    <li>
-    <ul>
-    <li>
-    <a href="#qux">Qux</a></li>
-    </ul>
-    </li>
-    </ul>
-    </li>
-    </ul>
-    <h1 id="foo">Foo</h1>
-    <h2 id="bar">Bar</h2>
-    <h1 id="baz">Baz</h1>
-    <h3 id="qux">Qux</h3>
-
-- desc: title depth > 6
-  titleDepth: 7
-  give: |
-    # Foo
-
-    ## Bar
-
-    # Baz
-
-    ### Qux
-  want: |
-    <h6 id="table-of-contents">Table of Contents</h6>
+    <p id="toc-title">Table of Contents</p>
     <ul>
     <li>
     <a href="#foo">Foo</a><ul>

--- a/transform_test.go
+++ b/transform_test.go
@@ -1,7 +1,6 @@
 package toc
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -56,83 +55,11 @@ func TestTransformer(t *testing.T) {
 				),
 			).Parse(text.NewReader(src))
 
-			heading, ok := doc.FirstChild().(*ast.Heading)
-			require.True(t, ok, "first child must be a heading, got %T", doc.FirstChild())
-			gotTitle := nodeText(src, heading)
+			paragraph, ok := doc.FirstChild().(*ast.Paragraph)
+			require.True(t, ok, "first child must be a paragraph, got %T", doc.FirstChild())
+			gotTitle := nodeText(src, paragraph)
 			assert.Equal(t, tt.wantTitle, string(gotTitle), "title mismatch")
 		})
 	}
 }
 
-// From: https://github.com/abhinav/goldmark-toc/issues/61
-func TestTransformerWithTitleDepth(t *testing.T) {
-	t.Parallel()
-
-	src := []byte(strings.Join([]string{
-		"# Hey",
-		"## Now",
-		"# Then",
-		"### There",
-		"## Now",
-	}, "\n") + "\n")
-
-	type testCase struct {
-		desc      string
-		giveDepth int
-		wantDepth int
-	}
-
-	tests := []testCase{
-		{
-			desc:      "default",
-			wantDepth: _defaultTitleDepth,
-		},
-		{
-			desc:      "< 1",
-			giveDepth: -1,
-			wantDepth: 1,
-		},
-		{
-			desc:      "> 6",
-			giveDepth: 7,
-			wantDepth: 6,
-		},
-		{
-			desc:      "absurd",
-			giveDepth: 130931,
-			wantDepth: 6,
-		},
-	}
-
-	for i := _defaultTitleDepth; i <= _maxTitleDepth; i++ {
-		tests = append(tests, testCase{
-			desc:      fmt.Sprintf("valid/%d", i),
-			giveDepth: i,
-			wantDepth: i,
-		})
-	}
-
-	for _, tt := range tests {
-		tt := tt // for t.Parallel
-		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
-			doc := parser.NewParser(
-				parser.WithInlineParsers(parser.DefaultInlineParsers()...),
-				parser.WithBlockParsers(parser.DefaultBlockParsers()...),
-				parser.WithAutoHeadingID(),
-				parser.WithASTTransformers(
-					util.Prioritized(&Transformer{
-						TitleDepth: tt.giveDepth,
-					}, 100),
-				),
-			).Parse(text.NewReader(src))
-
-			// Should definitely still be a heading
-			heading, ok := doc.FirstChild().(*ast.Heading)
-
-			require.True(t, ok, "first child must be a heading, got %T", doc.FirstChild())
-			assert.Equal(t, tt.wantDepth, heading.Level, "level mismatch")
-		})
-	}
-}


### PR DESCRIPTION
  ### Changes

  1. **Title element changed from heading to paragraph** - The TOC title now renders as `<p>` instead of `<h1>`-`<h6>`, since it's a UI label rather than part of the document's content hierarchy.

  2. **Automatic aria-label for accessibility** - When `HideTitle: true` is combined with `ContainerElement`, the container automatically gets an `aria-label` attribute with the title text.

  3. **Removed `TitleDepth` option** - No longer needed since title is always a `<p>`.

  ### Breaking Changes

  - `TitleDepth` field removed from `Transformer` and `Extender`
  - Title renders as `<p id="...">` instead of `<h1 id="...">`

  ### Example

  ```go
  &toc.Extender{
      Title:            "Navigation",
      HideTitle:        true,
      ContainerElement: "nav",
  }
  // Output: <nav aria-label="Navigation"><ul>...</ul></nav>